### PR TITLE
chore: bump version to 0.0.8 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@falkordb/canvas",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@falkordb/canvas",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falkordb/canvas",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A standalone web component for visualizing FalkorDB graphs using force-directed layouts",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR updates the project's version number to `0.0.8` in preparation for a new release or to reflect recent changes.

#### Key Changes
- The `version` field in `package.json` was updated from `0.0.7` to `0.0.8`.
- The corresponding `version` field in `package-lock.json` was also updated to `0.0.8`.

#### Work Breakdown

| Category | Lines Changed |
|---|---|
| Rework | 3 (100.0%) |
| Total Changes | 3 | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This is a maintenance release with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->