### PR TITLE
feat: update version to 0.0.14 and modify canvas simulation attribute…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@falkordb/canvas",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@falkordb/canvas",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falkordb/canvas",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A standalone web component for visualizing FalkorDB graphs using force-directed layouts",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -193,6 +193,8 @@ class FalkorDBCanvas extends HTMLElement {
     if (this.graph) {
       this.graph.cooldownTicks(ticks ?? Infinity);
     }
+
+    this.updateCanvasSimulationAttribute(ticks !== 0);
   }
 
   setDisplayTextPriority(priority: ForceGraphConfig['displayTextPriority']) {
@@ -320,8 +322,9 @@ class FalkorDBCanvas extends HTMLElement {
     if (!this.shadowRoot) return;
     
     const canvas = this.shadowRoot.querySelector("canvas") as HTMLCanvasElement;
+    
     if (canvas) {
-      canvas.setAttribute('data-simulation-running', isRunning.toString());
+      canvas.setAttribute('data-engine-status', isRunning ? "running" : "stopped");
     }
   }
 


### PR DESCRIPTION
… for running status
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the package version to `0.0.14` and refines the canvas simulation attribute handling. The changes ensure the canvas element accurately reflects the simulation's active state.

#### Key Changes
- Updated the package version from `0.0.13` to `0.0.14` in `package.json` and `package-lock.json`.
- Modified the `cooldownTicks` method to explicitly call `updateCanvasSimulationAttribute` based on whether ticks are provided.
- Changed the `updateCanvasSimulationAttribute` method to set a `data-engine-status` attribute on the canvas, indicating "running" or "stopped", instead of a boolean `data-simulation-running`.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| New Work | 3 (42.9%)     |
| Rework   | 4 (57.1%)     |
| Total Changes | 7           | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed canvas simulation state not re-evaluating when cooldown settings change.

* **Chores**
  * Version bumped to 0.0.14.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->