### PR TITLE
Add layout modes and example selector UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A standalone web component for visualizing FalkorDB graphs using force-directed 
 ## Features
 
 - 🎨 **Force-directed graph layout** - Automatic positioning using D3 force simulation with smart collision detection
+- 🧭 **Multiple layout modes** - Switch between `force`, `tree`, and `flow` graph views
 - 🎯 **Interactive** - Click, hover, right-click interactions on nodes, links, and background
 - 🌓 **Theme support** - Light and dark mode compatible with customizable colors
 - ⚡ **Performance** - Optimized rendering with HTML5 canvas
@@ -137,6 +138,8 @@ function GraphVisualization() {
 | `height` | `<window height>` | Canvas height in pixels |
 | `backgroundColor` | | Background color (hex or CSS color) |
 | `foregroundColor` | | Foreground color for borders and text |
+| `layoutMode` | `force` | Layout algorithm to use: `force` \| `tree` \| `flow` |
+| `layoutOptions` | `{}` | Per-layout options. Use `tree` options (`rootNodeId`, `direction`, `levelSpacing`, `nodeSpacing`, `componentSpacing`) and `flow` options (`direction`, `layerSpacing`, `nodeSpacing`, `componentSpacing`) |
 | `cooldownTicks` | `undefined` | Number of simulation ticks before stopping (undefined = infinite) |
 | `cooldownTime` | `1000` | Time in ms for each simulation tick |
 | `autoStopOnSettle` | `true` | Automatically stop simulation when settled |
@@ -156,6 +159,43 @@ function GraphVisualization() {
 | `isLinkSelected` | | Function to determine if a link is selected. Signature: `(link: GraphLink) => boolean` |
 | `node` | | Custom node rendering functions (see Custom Rendering) |
 | `link` | | Custom link rendering functions (see Custom Rendering) |
+
+### Layout Modes
+
+Use `layoutMode` in `setConfig` to choose the graph view style:
+
+```typescript
+canvas.setConfig({
+  layoutMode: 'flow',
+  layoutOptions: {
+    flow: {
+      direction: 'LR',      // 'LR' | 'RL' | 'TB' | 'BT'
+      layerSpacing: 180,
+      nodeSpacing: 110
+    }
+  }
+});
+```
+
+Tree layout example:
+
+```typescript
+canvas.setConfig({
+  layoutMode: 'tree',
+  layoutOptions: {
+    tree: {
+      rootNodeId: 1,
+      direction: 'TB',
+      levelSpacing: 130,
+      nodeSpacing: 110
+    }
+  }
+});
+```
+
+Notes:
+- `force` keeps simulation enabled.
+- `tree` and `flow` pin node positions for stable deterministic views.
 
 ### Data Types
 

--- a/examples/falkordb-canvas.example.html
+++ b/examples/falkordb-canvas.example.html
@@ -55,6 +55,38 @@
       background: #45a049;
     }
 
+    .control-group {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-bottom: 10px;
+    }
+
+    .control-group:last-child {
+      margin-bottom: 0;
+    }
+
+    label {
+      color: #333;
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    select {
+      padding: 8px 10px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      background: #fff;
+      font-size: 14px;
+    }
+
+    select:disabled {
+      background: #f3f3f3;
+      color: #777;
+      cursor: not-allowed;
+    }
+
     .info {
       margin-top: 20px;
       padding: 15px;
@@ -74,9 +106,27 @@
     <h1>FalkorDB Canvas Web Component</h1>
 
     <div class="controls">
-      <button onclick="addNode()">Add Node</button>
-      <button onclick="addLink()">Add Link</button>
-      <button onclick="toggleLoading()">Toggle Loading</button>
+      <div class="control-group">
+        <button onclick="addNode()">Add Node</button>
+        <button onclick="addLink()">Add Link</button>
+        <button onclick="toggleLoading()">Toggle Loading</button>
+      </div>
+      <div class="control-group">
+        <label for="layout-select">Layout</label>
+        <select id="layout-select" onchange="changeLayout()">
+          <option value="force" selected>Force</option>
+          <option value="tree">Tree</option>
+          <option value="flow">Flow</option>
+        </select>
+
+        <label for="layout-direction-select">Direction</label>
+        <select id="layout-direction-select" onchange="changeLayout()">
+          <option value="TB">Top → Bottom</option>
+          <option value="BT">Bottom → Top</option>
+          <option value="LR" selected>Left → Right</option>
+          <option value="RL">Right → Left</option>
+        </select>
+      </div>
     </div>
 
     <div class="graph-container">
@@ -107,6 +157,63 @@
     let canvas;
     let nodeCounter = 1;
     let linkCounter = 1;
+    const layoutSelect = document.getElementById('layout-select');
+    const layoutDirectionSelect = document.getElementById('layout-direction-select');
+
+    const updateDirectionControlState = (layoutMode) => {
+      if (!layoutDirectionSelect) return;
+      layoutDirectionSelect.disabled = layoutMode === 'force';
+    };
+
+    const getLayoutConfig = (layoutMode, direction) => {
+      if (layoutMode === 'tree') {
+        const data = canvas?.getData?.();
+        const firstNodeId = data?.nodes?.[0]?.id;
+
+        return {
+          layoutMode: 'tree',
+          layoutOptions: {
+            tree: {
+              direction,
+              ...(firstNodeId !== undefined ? { rootNodeId: firstNodeId } : {})
+            }
+          }
+        };
+      }
+
+      if (layoutMode === 'flow') {
+        return {
+          layoutMode: 'flow',
+          layoutOptions: {
+            flow: {
+              direction
+            }
+          }
+        };
+      }
+
+      return {
+        layoutMode: 'force',
+        layoutOptions: {}
+      };
+    };
+
+    window.changeLayout = () => {
+      if (!layoutSelect || !layoutDirectionSelect) return;
+
+      const layoutMode = layoutSelect.value;
+      const direction = layoutDirectionSelect.value;
+      updateDirectionControlState(layoutMode);
+
+      if (!canvas) {
+        alert('Graph not loaded yet, please wait...');
+        return;
+      }
+
+      canvas.setConfig(getLayoutConfig(layoutMode, direction));
+      document.getElementById('selected-info').textContent =
+        `Layout: ${layoutMode.toUpperCase()}${layoutMode === 'force' ? '' : ` (${direction})`}`;
+    };
 
     window.addNode = () => {
       if (!canvas) {
@@ -369,6 +476,12 @@
       isNodeSelected: (node) => false,
       isLinkSelected: (link) => false,
     });
+
+    // Initialize layout controls and apply selected layout
+    if (layoutSelect) {
+      updateDirectionControlState(layoutSelect.value);
+    }
+    window.changeLayout();
 
     // Update counters based on loaded data
     nodeCounter = Math.max(...graphData.nodes.map(n => n.id), 0) + 1;

--- a/examples/falkordb-canvas.example.html
+++ b/examples/falkordb-canvas.example.html
@@ -151,7 +151,13 @@
 
   <!-- Import the web component -->
   <script type="module">
-    import 'https://cdn.jsdelivr.net/npm/@falkordb/canvas@0.0.16/dist/index.js';
+    try {
+      await import('../dist/index.js');
+      console.log('Loaded local ../dist/index.js');
+    } catch (error) {
+      console.warn('Falling back to CDN package because local build could not be loaded.', error);
+      await import('https://cdn.jsdelivr.net/npm/@falkordb/canvas@0.0.16/dist/index.js');
+    }
 
     // Define control functions FIRST so they're available immediately for onclick handlers
     let canvas;
@@ -273,13 +279,36 @@
     };
 
     // Now load the graph data
+    const SAMPLE_GRAPH_DATA = {
+      nodes: [
+        { id: 1, labels: ['Person'], color: '#FF6B6B', visible: true, data: { name: 'Alice' } },
+        { id: 2, labels: ['Person'], color: '#4ECDC4', visible: true, data: { name: 'Bob' } },
+        { id: 3, labels: ['Person'], color: '#45B7D1', visible: true, data: { name: 'Charlie' } },
+        { id: 4, labels: ['Company'], color: '#FFA07A', visible: true, data: { name: 'FalkorDB' } },
+        { id: 5, labels: ['City'], color: '#96CEB4', visible: true, data: { name: 'Tel Aviv' } }
+      ],
+      links: [
+        { id: 1, relationship: 'KNOWS', color: '#888', source: 1, target: 2, visible: true, data: {} },
+        { id: 2, relationship: 'KNOWS', color: '#888', source: 2, target: 3, visible: true, data: {} },
+        { id: 3, relationship: 'WORKS_AT', color: '#666', source: 1, target: 4, visible: true, data: {} },
+        { id: 4, relationship: 'WORKS_AT', color: '#666', source: 3, target: 4, visible: true, data: {} },
+        { id: 5, relationship: 'LIVES_IN', color: '#999', source: 1, target: 5, visible: true, data: {} },
+        { id: 6, relationship: 'LIVES_IN', color: '#999', source: 2, target: 5, visible: true, data: {} }
+      ]
+    };
+
     const API_TOKEN = 'your_api_token_here'; // Replace with your actual API token
     const graphName = 'your_graph_name_here'; // Replace with your actual graph name
     const query = 'your_query_here'; // Replace with your actual query
 
+    const shouldFetchRemote =
+      API_TOKEN !== 'your_api_token_here' &&
+      graphName !== 'your_graph_name_here' &&
+      query !== 'your_query_here';
+
     const url = `https://browser.falkordb.com/api/graph/${encodeURIComponent(graphName)}?query=${encodeURIComponent(query)}`;
 
-    let graphData = { nodes: [], links: [] };
+    let graphData = JSON.parse(JSON.stringify(SAMPLE_GRAPH_DATA));
 
     // Color palettes
     const labelColors = {};
@@ -309,115 +338,120 @@
       return relationshipColors[type];
     };
 
-    try {
-      // Use fetch with manual SSE parsing (simpler than polyfill)
-      await new Promise(async (resolve, reject) => {
-        try {
-          const response = await fetch(url, {
-            method: 'GET',
-            headers: {
-              'Authorization': `Bearer ${API_TOKEN}`,
-            }
-          });
-
-          const reader = response.body.getReader();
-          const decoder = new TextDecoder();
-          let buffer = '';
-
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-
-            buffer += decoder.decode(value, { stream: true });
-
-            // Process complete events
-            const events = buffer.split('\n\n');
-            buffer = events.pop(); // Keep incomplete event in buffer
-
-            for (const event of events) {
-              if (!event.trim()) continue;
-
-              const lines = event.split('\n');
-              let eventType = '';
-              let data = '';
-
-              for (const line of lines) {
-                if (line.startsWith('event:')) {
-                  eventType = line.substring(6).trim();
-                } else if (line.startsWith('data:')) {
-                  data += line.substring(5);
-                }
+    if (shouldFetchRemote) {
+      graphData = { nodes: [], links: [] };
+      try {
+        // Use fetch with manual SSE parsing (simpler than polyfill)
+        await new Promise(async (resolve, reject) => {
+          try {
+            const response = await fetch(url, {
+              method: 'GET',
+              headers: {
+                'Authorization': `Bearer ${API_TOKEN}`,
               }
+            });
 
-              if (eventType === 'result' && data) {
-                const result = JSON.parse(data);
-                console.log('Query result:', result);
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let buffer = '';
 
-                // Convert to falkordb-canvas format
-                if (result.data && Array.isArray(result.data)) {
-                  result.data.forEach(row => {
-                    if (row.n) {
-                      const primaryLabel = row.n.labels[0] || 'Unknown';
-                      const node = {
-                        id: row.n.id,
-                        labels: row.n.labels,
-                        data: row.n.properties,
-                        visible: true,
-                        color: getColorForLabel(primaryLabel)
-                      };
-                      // Avoid duplicates
-                      if (!graphData.nodes.find(n => n.id === node.id)) {
-                        graphData.nodes.push(node);
-                      }
-                    }
-                    // Add target node if present
-                    if (row.m) {
-                      const primaryLabel = row.m.labels[0] || 'Unknown';
-                      const targetNode = {
-                        id: row.m.id,
-                        labels: row.m.labels,
-                        data: row.m.properties,
-                        visible: true,
-                        color: getColorForLabel(primaryLabel)
-                      };
-                      if (!graphData.nodes.find(n => n.id === targetNode.id)) {
-                        graphData.nodes.push(targetNode);
-                      }
-                    }
-                    // Add links if relationship present
-                    if (row.e && row.n && row.m) {
-                      const relType = row.e.relationshipType || 'RELATED';
-                      const link = {
-                        id: row.e.id,
-                        source: row.e.sourceId,
-                        target: row.e.destinationId,
-                        relationship: relType,
-                        data: row.e.properties || {},
-                        color: getColorForRelationship(relType),
-                        visible: true
-                      };
-                      if (!graphData.links.find(l => l.id === link.id)) {
-                        graphData.links.push(link);
-                      }
-                    }
-                  });
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+
+              buffer += decoder.decode(value, { stream: true });
+
+              // Process complete events
+              const events = buffer.split('\n\n');
+              buffer = events.pop(); // Keep incomplete event in buffer
+
+              for (const event of events) {
+                if (!event.trim()) continue;
+
+                const lines = event.split('\n');
+                let eventType = '';
+                let data = '';
+
+                for (const line of lines) {
+                  if (line.startsWith('event:')) {
+                    eventType = line.substring(6).trim();
+                  } else if (line.startsWith('data:')) {
+                    data += line.substring(5);
+                  }
                 }
 
-                resolve(result);
-              } else if (eventType === 'error' && data) {
-                const { message } = JSON.parse(data);
-                console.error('Error:', message);
-                reject(new Error(message));
+                if (eventType === 'result' && data) {
+                  const result = JSON.parse(data);
+                  console.log('Query result:', result);
+
+                  // Convert to falkordb-canvas format
+                  if (result.data && Array.isArray(result.data)) {
+                    result.data.forEach(row => {
+                      if (row.n) {
+                        const primaryLabel = row.n.labels[0] || 'Unknown';
+                        const node = {
+                          id: row.n.id,
+                          labels: row.n.labels,
+                          data: row.n.properties,
+                          visible: true,
+                          color: getColorForLabel(primaryLabel)
+                        };
+                        // Avoid duplicates
+                        if (!graphData.nodes.find(n => n.id === node.id)) {
+                          graphData.nodes.push(node);
+                        }
+                      }
+                      // Add target node if present
+                      if (row.m) {
+                        const primaryLabel = row.m.labels[0] || 'Unknown';
+                        const targetNode = {
+                          id: row.m.id,
+                          labels: row.m.labels,
+                          data: row.m.properties,
+                          visible: true,
+                          color: getColorForLabel(primaryLabel)
+                        };
+                        if (!graphData.nodes.find(n => n.id === targetNode.id)) {
+                          graphData.nodes.push(targetNode);
+                        }
+                      }
+                      // Add links if relationship present
+                      if (row.e && row.n && row.m) {
+                        const relType = row.e.relationshipType || 'RELATED';
+                        const link = {
+                          id: row.e.id,
+                          source: row.e.sourceId,
+                          target: row.e.destinationId,
+                          relationship: relType,
+                          data: row.e.properties || {},
+                          color: getColorForRelationship(relType),
+                          visible: true
+                        };
+                        if (!graphData.links.find(l => l.id === link.id)) {
+                          graphData.links.push(link);
+                        }
+                      }
+                    });
+                  }
+
+                  resolve(result);
+                } else if (eventType === 'error' && data) {
+                  const { message } = JSON.parse(data);
+                  console.error('Error:', message);
+                  reject(new Error(message));
+                }
               }
             }
+          } catch (error) {
+            console.error('Fetch error:', error);
+            reject(error);
           }
-        } catch (error) {
-          console.error('Fetch error:', error);
-          reject(error);
-        }
-      });
-    } catch (error) {
-      alert(error.message);
+        });
+      } catch (error) {
+        alert(error.message);
+      }
+    } else {
+      console.log('Using built-in sample graph data. Set API_TOKEN/graphName/query to fetch remote data.');
     }
 
     // Get the graph element

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -5,6 +5,8 @@ export interface ForceGraphConfig {
   height?: number;
   backgroundColor?: string;
   foregroundColor?: string;
+  layoutMode?: LayoutMode;
+  layoutOptions?: LayoutOptions;
   onNodeClick?: (node: GraphNode, event: MouseEvent) => void;
   onLinkClick?: (link: GraphLink, event: MouseEvent) => void;
   onNodeRightClick?: (node: GraphNode, event: MouseEvent) => void;
@@ -35,11 +37,37 @@ export interface ForceGraphConfig {
   };
 }
 
-export interface InternalForceGraphConfig extends Omit<ForceGraphConfig, 'backgroundColor' | 'foregroundColor' | 'captionsKeys' | 'showPropertyKeyPrefix'> {
+export interface InternalForceGraphConfig extends Omit<ForceGraphConfig, 'backgroundColor' | 'foregroundColor' | 'captionsKeys' | 'showPropertyKeyPrefix' | 'layoutMode' | 'layoutOptions'> {
   backgroundColor: string;
   foregroundColor: string;
   captionsKeys: string[];
   showPropertyKeyPrefix: boolean;
+  layoutMode: LayoutMode;
+  layoutOptions: LayoutOptions;
+}
+
+export type LayoutMode = 'force' | 'flow' | 'tree';
+
+export type LayoutDirection = 'TB' | 'BT' | 'LR' | 'RL';
+
+export interface TreeLayoutOptions {
+  rootNodeId?: number;
+  direction?: LayoutDirection;
+  levelSpacing?: number;
+  nodeSpacing?: number;
+  componentSpacing?: number;
+}
+
+export interface FlowLayoutOptions {
+  direction?: LayoutDirection;
+  layerSpacing?: number;
+  nodeSpacing?: number;
+  componentSpacing?: number;
+}
+
+export interface LayoutOptions {
+  tree?: TreeLayoutOptions;
+  flow?: FlowLayoutOptions;
 }
 
 export type GraphNode = NodeObject & {

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -219,6 +219,7 @@ class FalkorDBCanvas extends HTMLElement {
           if (this.data.nodes.length > 0) {
             this.zoomToFit(1);
           }
+          this.triggerRender();
         }
       }
     }
@@ -337,6 +338,7 @@ class FalkorDBCanvas extends HTMLElement {
 
     if (!this.isForceLayoutMode() && this.data.nodes.length > 0) {
       this.zoomToFit(1);
+      this.triggerRender();
     }
 
     this.updateLoadingState();
@@ -387,6 +389,7 @@ class FalkorDBCanvas extends HTMLElement {
       this.updateLoadingState();
       if (this.data.nodes.length > 0) {
         this.zoomToFit(1);
+        this.triggerRender();
       }
     }
 

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -22,6 +22,7 @@ import {
   LINK_DISTANCE,
   wrapTextForCircularNode,
 } from "./canvas-utils.js";
+import { applyGraphLayout, isForceLayout } from "./layouts.js";
 
 const PADDING = 2;
 // Arrow geometry constants (shared by self-loop and regular-link drawing paths)
@@ -92,6 +93,8 @@ class FalkorDBCanvas extends HTMLElement {
     foregroundColor: '#1A1A1A',
     captionsKeys: [],
     showPropertyKeyPrefix: false,
+    layoutMode: "force",
+    layoutOptions: {},
   };
 
   private nodeMode: CanvasRenderMode = 'replace';
@@ -183,6 +186,7 @@ class FalkorDBCanvas extends HTMLElement {
 
   setConfig(config: Partial<ForceGraphConfig>) {
     this.log('Setting config:', config);
+    const layoutChanged = config.layoutMode !== undefined || config.layoutOptions !== undefined;
 
     // If captionsKeys changed, invalidate cached display names and font sizes
     // so text is recomputed with the new keys on the next render.
@@ -194,6 +198,30 @@ class FalkorDBCanvas extends HTMLElement {
     }
 
     Object.assign(this.config, config);
+
+    if (layoutChanged) {
+      if (this.isForceLayoutMode() && this.config.cooldownTicks === 0 && this.data.nodes.length > 0) {
+        this.config.cooldownTicks = undefined;
+      }
+      this.data = applyGraphLayout(this.data, this.config.layoutMode, this.config.layoutOptions);
+      if (this.graph) {
+        this.calculateNodeDegree();
+        this.graph.graphData(this.data);
+        this.configureSimulationForCurrentLayout();
+        if (this.isForceLayoutMode()) {
+          this.config.isLoading = this.data.nodes.length > 0;
+          this.config.onLoadingChange?.(this.config.isLoading);
+          this.updateLoadingState();
+        } else {
+          this.config.isLoading = false;
+          this.config.onLoadingChange?.(false);
+          this.updateLoadingState();
+          if (this.data.nodes.length > 0) {
+            this.zoomToFit(1);
+          }
+        }
+      }
+    }
 
     // Update event handlers if they were provided
     if (config.onNodeClick || config.onLinkClick || config.onNodeRightClick || config.onLinkRightClick ||
@@ -255,10 +283,12 @@ class FalkorDBCanvas extends HTMLElement {
     this.log('Setting cooldown ticks to:', ticks);
     this.config.cooldownTicks = ticks;
     if (this.graph) {
-      this.graph.cooldownTicks(ticks ?? Infinity);
+      this.graph.cooldownTicks(this.isForceLayoutMode() ? (ticks ?? Infinity) : 0);
     }
 
-    this.updateCanvasSimulationAttribute(ticks !== 0);
+    this.updateCanvasSimulationAttribute(
+      this.isForceLayoutMode() && ticks !== 0 && this.data.nodes.length > 0
+    );
   }
 
   getData(): Data {
@@ -269,15 +299,23 @@ class FalkorDBCanvas extends HTMLElement {
     this.log('setData called with', data.nodes.length, 'nodes and', data.links.length, 'links');
     // Convert data and apply circular layout to new nodes only
     this.data = dataToGraphData(data);
+    this.data = applyGraphLayout(this.data, this.config.layoutMode, this.config.layoutOptions);
 
-    this.config.cooldownTicks = this.data.nodes.length > 0 ? undefined : 0;
-    this.config.isLoading = this.data.nodes.length > 0;
+    if (this.isForceLayoutMode()) {
+      this.config.cooldownTicks = this.data.nodes.length > 0 ? undefined : 0;
+      this.config.isLoading = this.data.nodes.length > 0;
+    } else {
+      this.config.cooldownTicks = 0;
+      this.config.isLoading = false;
+    }
     this.log('Loading state:', this.config.isLoading);
     this.config.onLoadingChange?.(this.config.isLoading);
 
     // Update simulation state
-    if (this.data.nodes.length > 0) {
+    if (this.data.nodes.length > 0 && this.isForceLayoutMode()) {
       this.updateCanvasSimulationAttribute(true);
+    } else {
+      this.updateCanvasSimulationAttribute(false);
     }
 
     // Initialize graph if it hasn't been initialized yet
@@ -290,12 +328,16 @@ class FalkorDBCanvas extends HTMLElement {
 
     this.log('Calculating node degrees and setting up forces');
     this.calculateNodeDegree();
-    this.setupForces();
 
     // Update graph data and properties
     this.graph
-      .graphData(this.data)
-      .cooldownTicks(this.config.cooldownTicks ?? Infinity);
+      .graphData(this.data);
+
+    this.configureSimulationForCurrentLayout();
+
+    if (!this.isForceLayoutMode() && this.data.nodes.length > 0) {
+      this.zoomToFit(1);
+    }
 
     this.updateLoadingState();
   }
@@ -325,16 +367,28 @@ class FalkorDBCanvas extends HTMLElement {
 
   setGraphData(data: GraphData) {
     this.log('setGraphData called with', data.nodes.length, 'nodes and', data.links.length, 'links');
+    this.data = applyGraphLayout(data, this.config.layoutMode, this.config.layoutOptions);
 
-    this.data = data;
+    if (this.isForceLayoutMode() && this.config.cooldownTicks === 0 && this.data.nodes.length > 0) {
+      this.config.cooldownTicks = undefined;
+    }
 
     if (!this.graph) return;
 
     this.calculateNodeDegree();
-    this.setupForces();
 
     this.graph
-      .graphData(this.data)
+      .graphData(this.data);
+    this.configureSimulationForCurrentLayout();
+
+    if (!this.isForceLayoutMode()) {
+      this.config.isLoading = false;
+      this.config.onLoadingChange?.(false);
+      this.updateLoadingState();
+      if (this.data.nodes.length > 0) {
+        this.zoomToFit(1);
+      }
+    }
 
     if (this.viewport) {
       this.log('Applying viewport:', this.viewport);
@@ -375,6 +429,25 @@ class FalkorDBCanvas extends HTMLElement {
     this.log('Zooming to fit with padding multiplier:', paddingMultiplier, 'padding:', padding * paddingMultiplier);
     // Use the force-graph's built-in zoomToFit method
     this.graph.zoomToFit(500, padding * paddingMultiplier, filter);
+  }
+
+  private isForceLayoutMode() {
+    return isForceLayout(this.config.layoutMode);
+  }
+
+  private configureSimulationForCurrentLayout() {
+    if (!this.graph) return;
+
+    if (this.isForceLayoutMode()) {
+      this.setupForces();
+      const cooldownTicks = this.config.cooldownTicks ?? Infinity;
+      this.graph.cooldownTicks(cooldownTicks);
+      this.updateCanvasSimulationAttribute(cooldownTicks !== 0 && this.data.nodes.length > 0);
+      return;
+    }
+
+    this.graph.cooldownTicks(0);
+    this.updateCanvasSimulationAttribute(false);
   }
 
   private triggerRender() {
@@ -548,7 +621,7 @@ class FalkorDBCanvas extends HTMLElement {
       .linkCurvature("curve")
       .linkVisibility("visible")
       .nodeVisibility("visible")
-      .cooldownTicks(this.config.cooldownTicks ?? Infinity) // undefined = infinite
+      .cooldownTicks(this.isForceLayoutMode() ? (this.config.cooldownTicks ?? Infinity) : 0) // undefined = infinite
       .cooldownTime(this.config.cooldownTime ?? 2000)
       .enableNodeDrag(true)
       .enableZoomInteraction(true)
@@ -633,8 +706,7 @@ class FalkorDBCanvas extends HTMLElement {
         }
       });
 
-    // Setup forces
-    this.setupForces();
+    this.configureSimulationForCurrentLayout();
     this.log('Force graph initialization complete');
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 import FalkorDBCanvas from "./canvas.js";
 import type React from "react";
-import type { CanvasRenderMode } from "./canvas-types.js";
+import type {
+  CanvasRenderMode,
+  FlowLayoutOptions,
+  LayoutDirection,
+  LayoutMode,
+  LayoutOptions,
+  TreeLayoutOptions,
+} from "./canvas-types.js";
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -26,6 +33,11 @@ export { FalkorDBCanvas as default, FalkorDBCanvas };
 // Types
 export type {
   CanvasRenderMode,
+  LayoutMode,
+  LayoutDirection,
+  LayoutOptions,
+  TreeLayoutOptions,
+  FlowLayoutOptions,
 }
 
 export type {

--- a/src/layouts.ts
+++ b/src/layouts.ts
@@ -1,0 +1,458 @@
+import * as d3 from "d3";
+import {
+  FlowLayoutOptions,
+  GraphData,
+  GraphNode,
+  LayoutDirection,
+  LayoutMode,
+  LayoutOptions,
+  TreeLayoutOptions,
+} from "./canvas-types.js";
+
+type LayoutPoint = { x: number; y: number };
+
+type TreeNode = {
+  id: number;
+  children: TreeNode[];
+};
+
+const DEFAULT_LAYOUT_MODE: LayoutMode = "force";
+const DEFAULT_TREE_OPTIONS: Required<Omit<TreeLayoutOptions, "rootNodeId">> = {
+  direction: "TB",
+  levelSpacing: 130,
+  nodeSpacing: 110,
+  componentSpacing: 180,
+};
+const DEFAULT_FLOW_OPTIONS: Required<FlowLayoutOptions> = {
+  direction: "LR",
+  layerSpacing: 180,
+  nodeSpacing: 110,
+  componentSpacing: 220,
+};
+
+function orientPoint(x: number, y: number, direction: LayoutDirection): LayoutPoint {
+  switch (direction) {
+    case "BT":
+      return { x, y: -y };
+    case "LR":
+      return { x: y, y: x };
+    case "RL":
+      return { x: -y, y: x };
+    case "TB":
+    default:
+      return { x, y };
+  }
+}
+
+function centerNodePositions(nodes: GraphNode[]) {
+  if (nodes.length === 0) return;
+
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (const node of nodes) {
+    const x = node.x ?? 0;
+    const y = node.y ?? 0;
+    minX = Math.min(minX, x);
+    maxX = Math.max(maxX, x);
+    minY = Math.min(minY, y);
+    maxY = Math.max(maxY, y);
+  }
+
+  const centerX = (minX + maxX) / 2;
+  const centerY = (minY + maxY) / 2;
+
+  for (const node of nodes) {
+    node.x = (node.x ?? 0) - centerX;
+    node.y = (node.y ?? 0) - centerY;
+  }
+}
+
+function pinAllNodes(nodes: GraphNode[]) {
+  for (const node of nodes) {
+    const x = node.x ?? 0;
+    const y = node.y ?? 0;
+    node.x = x;
+    node.y = y;
+    node.fx = x;
+    node.fy = y;
+    node.vx = 0;
+    node.vy = 0;
+    node.initialPositionCalculated = true;
+  }
+}
+
+function unpinAllNodes(nodes: GraphNode[]) {
+  for (const node of nodes) {
+    node.fx = undefined;
+    node.fy = undefined;
+  }
+}
+
+function createAdjacency(graphData: GraphData) {
+  const nodeIds = graphData.nodes.map((node) => node.id);
+  const nodeIdSet = new Set<number>(nodeIds);
+  const outgoing = new Map<number, number[]>();
+  const incoming = new Map<number, number[]>();
+  const inDegree = new Map<number, number>();
+
+  for (const id of nodeIds) {
+    outgoing.set(id, []);
+    incoming.set(id, []);
+    inDegree.set(id, 0);
+  }
+
+  for (const link of graphData.links) {
+    const sourceId = link.source.id;
+    const targetId = link.target.id;
+
+    if (!nodeIdSet.has(sourceId) || !nodeIdSet.has(targetId)) continue;
+    if (sourceId === targetId) continue;
+
+    const sourceOutgoing = outgoing.get(sourceId);
+    const targetIncoming = incoming.get(targetId);
+
+    if (!sourceOutgoing || !targetIncoming) continue;
+    if (sourceOutgoing.includes(targetId)) continue;
+
+    sourceOutgoing.push(targetId);
+    targetIncoming.push(sourceId);
+    inDegree.set(targetId, (inDegree.get(targetId) ?? 0) + 1);
+  }
+
+  for (const ids of outgoing.values()) {
+    ids.sort((a, b) => a - b);
+  }
+
+  for (const ids of incoming.values()) {
+    ids.sort((a, b) => a - b);
+  }
+
+  return { nodeIds, outgoing, incoming, inDegree };
+}
+
+function applyTreeLayout(graphData: GraphData, treeOptions?: TreeLayoutOptions) {
+  const options = { ...DEFAULT_TREE_OPTIONS, ...treeOptions };
+  const { nodeIds, outgoing, inDegree } = createAdjacency(graphData);
+  const nodeIdSet = new Set<number>(nodeIds);
+  const visited = new Set<number>();
+  const forest: TreeNode[] = [];
+
+  if (nodeIds.length === 0) return;
+
+  const preferredRoots: number[] = [];
+  if (treeOptions?.rootNodeId !== undefined && nodeIdSet.has(treeOptions.rootNodeId)) {
+    preferredRoots.push(treeOptions.rootNodeId);
+  }
+
+  const inDegreeRoots = nodeIds.filter((nodeId) => (inDegree.get(nodeId) ?? 0) === 0);
+  for (const rootId of inDegreeRoots) {
+    if (!preferredRoots.includes(rootId)) preferredRoots.push(rootId);
+  }
+
+  if (preferredRoots.length === 0) {
+    preferredRoots.push(nodeIds[0]);
+  }
+
+  const addTreeRoot = (rootId: number) => {
+    if (visited.has(rootId)) return;
+
+    const root: TreeNode = { id: rootId, children: [] };
+    const queue: Array<{ node: TreeNode; id: number }> = [{ node: root, id: rootId }];
+    visited.add(rootId);
+
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current) continue;
+
+      const children = outgoing.get(current.id) ?? [];
+      for (const childId of children) {
+        if (visited.has(childId)) continue;
+
+        visited.add(childId);
+        const childNode: TreeNode = { id: childId, children: [] };
+        current.node.children.push(childNode);
+        queue.push({ node: childNode, id: childId });
+      }
+    }
+
+    forest.push(root);
+  };
+
+  for (const rootId of preferredRoots) {
+    addTreeRoot(rootId);
+  }
+
+  for (const nodeId of nodeIds) {
+    addTreeRoot(nodeId);
+  }
+
+  const positionByNodeId = new Map<number, LayoutPoint>();
+  let breadthOffset = 0;
+
+  for (const treeRoot of forest) {
+    const rootHierarchy = d3.hierarchy(treeRoot, (node) => node.children);
+    const treeLayout = d3
+      .tree<TreeNode>()
+      .nodeSize([options.nodeSpacing, options.levelSpacing]);
+
+    treeLayout(rootHierarchy);
+
+    let minBreadth = Number.POSITIVE_INFINITY;
+    let maxBreadth = Number.NEGATIVE_INFINITY;
+    rootHierarchy.each((node) => {
+      const breadth = node.x ?? 0;
+      minBreadth = Math.min(minBreadth, breadth);
+      maxBreadth = Math.max(maxBreadth, breadth);
+    });
+
+    rootHierarchy.each((node) => {
+      const localBreadth = (node.x ?? 0) - minBreadth + breadthOffset;
+      const localDepth = node.y ?? 0;
+      positionByNodeId.set(
+        node.data.id,
+        orientPoint(localBreadth, localDepth, options.direction)
+      );
+    });
+
+    const componentBreadth = maxBreadth - minBreadth;
+    breadthOffset += componentBreadth + options.componentSpacing;
+  }
+
+  for (const node of graphData.nodes) {
+    const position = positionByNodeId.get(node.id);
+    if (!position) continue;
+
+    node.x = position.x;
+    node.y = position.y;
+  }
+
+  centerNodePositions(graphData.nodes);
+}
+
+function collectWeaklyConnectedComponents(
+  nodeIds: number[],
+  outgoing: Map<number, number[]>,
+  incoming: Map<number, number[]>
+): number[][] {
+  const visited = new Set<number>();
+  const components: number[][] = [];
+
+  for (const nodeId of nodeIds) {
+    if (visited.has(nodeId)) continue;
+
+    const queue: number[] = [nodeId];
+    const component: number[] = [];
+    visited.add(nodeId);
+
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (current === undefined) continue;
+      component.push(current);
+
+      const neighbors = [
+        ...(outgoing.get(current) ?? []),
+        ...(incoming.get(current) ?? []),
+      ];
+
+      for (const next of neighbors) {
+        if (visited.has(next)) continue;
+        visited.add(next);
+        queue.push(next);
+      }
+    }
+
+    component.sort((a, b) => a - b);
+    components.push(component);
+  }
+
+  return components;
+}
+
+function assignFlowLayers(
+  componentNodeIds: number[],
+  outgoing: Map<number, number[]>,
+  incoming: Map<number, number[]>
+): Map<number, number> {
+  const componentSet = new Set(componentNodeIds);
+  const inDegree = new Map<number, number>();
+  const layers = new Map<number, number>();
+  const processed = new Set<number>();
+  const queue: number[] = [];
+
+  for (const nodeId of componentNodeIds) {
+    const degree = (incoming.get(nodeId) ?? []).filter((id) => componentSet.has(id)).length;
+    inDegree.set(nodeId, degree);
+    if (degree === 0) queue.push(nodeId);
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined) continue;
+    processed.add(current);
+
+    const currentLayer = layers.get(current) ?? 0;
+    const children = outgoing.get(current) ?? [];
+
+    for (const childId of children) {
+      if (!componentSet.has(childId)) continue;
+      if (childId === current) continue;
+
+      const nextLayer = Math.max(layers.get(childId) ?? 0, currentLayer + 1);
+      layers.set(childId, nextLayer);
+
+      const nextInDegree = (inDegree.get(childId) ?? 0) - 1;
+      inDegree.set(childId, nextInDegree);
+      if (nextInDegree === 0) queue.push(childId);
+    }
+  }
+
+  let maxAssignedLayer = 0;
+  for (const layer of layers.values()) {
+    maxAssignedLayer = Math.max(maxAssignedLayer, layer);
+  }
+
+  for (const nodeId of componentNodeIds) {
+    if (processed.has(nodeId)) continue;
+    const parentLayers = (incoming.get(nodeId) ?? [])
+      .filter((parentId) => componentSet.has(parentId))
+      .map((parentId) => layers.get(parentId))
+      .filter((layer): layer is number => layer !== undefined);
+
+    const fallbackLayer = maxAssignedLayer + 1;
+    const layer = parentLayers.length > 0 ? Math.max(...parentLayers) + 1 : fallbackLayer;
+    layers.set(nodeId, layer);
+    maxAssignedLayer = Math.max(maxAssignedLayer, layer);
+  }
+
+  for (const nodeId of componentNodeIds) {
+    if (!layers.has(nodeId)) layers.set(nodeId, 0);
+  }
+
+  return layers;
+}
+
+function applyFlowLayout(graphData: GraphData, flowOptions?: FlowLayoutOptions) {
+  const options = { ...DEFAULT_FLOW_OPTIONS, ...flowOptions };
+  const { nodeIds, outgoing, incoming } = createAdjacency(graphData);
+  const components = collectWeaklyConnectedComponents(nodeIds, outgoing, incoming);
+  const positionByNodeId = new Map<number, LayoutPoint>();
+
+  let breadthOffset = 0;
+
+  for (const componentNodeIds of components) {
+    const componentSet = new Set(componentNodeIds);
+    const layersByNode = assignFlowLayers(componentNodeIds, outgoing, incoming);
+    const nodesByLayer = new Map<number, number[]>();
+    const priorLayerOrder = new Map<number, number>();
+
+    for (const nodeId of componentNodeIds) {
+      const layer = layersByNode.get(nodeId) ?? 0;
+      const layerNodes = nodesByLayer.get(layer) ?? [];
+      layerNodes.push(nodeId);
+      nodesByLayer.set(layer, layerNodes);
+    }
+
+    const sortedLayers = [...nodesByLayer.keys()].sort((a, b) => a - b);
+
+    for (const layer of sortedLayers) {
+      const layerNodes = nodesByLayer.get(layer);
+      if (!layerNodes) continue;
+
+      layerNodes.sort((a, b) => {
+        const aParents = (incoming.get(a) ?? [])
+          .filter((id) => componentSet.has(id))
+          .map((id) => priorLayerOrder.get(id))
+          .filter((index): index is number => index !== undefined);
+        const bParents = (incoming.get(b) ?? [])
+          .filter((id) => componentSet.has(id))
+          .map((id) => priorLayerOrder.get(id))
+          .filter((index): index is number => index !== undefined);
+
+        const aScore =
+          aParents.length > 0
+            ? aParents.reduce((sum, index) => sum + index, 0) / aParents.length
+            : Number.POSITIVE_INFINITY;
+        const bScore =
+          bParents.length > 0
+            ? bParents.reduce((sum, index) => sum + index, 0) / bParents.length
+            : Number.POSITIVE_INFINITY;
+
+        if (aScore === bScore) return a - b;
+        return aScore - bScore;
+      });
+
+      layerNodes.forEach((nodeId, index) => {
+        priorLayerOrder.set(nodeId, index);
+      });
+    }
+
+    let minBreadth = Number.POSITIVE_INFINITY;
+    let maxBreadth = Number.NEGATIVE_INFINITY;
+
+    for (const layer of sortedLayers) {
+      const layerNodes = nodesByLayer.get(layer);
+      if (!layerNodes) continue;
+
+      const centerIndex = (layerNodes.length - 1) / 2;
+      layerNodes.forEach((nodeId, index) => {
+        const breadth = (index - centerIndex) * options.nodeSpacing;
+        const depth = layer * options.layerSpacing;
+        minBreadth = Math.min(minBreadth, breadth);
+        maxBreadth = Math.max(maxBreadth, breadth);
+        positionByNodeId.set(nodeId, { x: breadth, y: depth });
+      });
+    }
+
+    for (const nodeId of componentNodeIds) {
+      const basePoint = positionByNodeId.get(nodeId);
+      if (!basePoint) continue;
+
+      const normalizedBreadth = basePoint.x - minBreadth + breadthOffset;
+      positionByNodeId.set(nodeId, { x: normalizedBreadth, y: basePoint.y });
+    }
+
+    const componentBreadth = maxBreadth - minBreadth;
+    breadthOffset += componentBreadth + options.componentSpacing;
+  }
+
+  for (const node of graphData.nodes) {
+    const basePoint = positionByNodeId.get(node.id);
+    if (!basePoint) continue;
+
+    const orientedPoint = orientPoint(basePoint.x, basePoint.y, options.direction);
+    node.x = orientedPoint.x;
+    node.y = orientedPoint.y;
+  }
+
+  centerNodePositions(graphData.nodes);
+}
+
+export function isForceLayout(layoutMode?: LayoutMode): boolean {
+  return (layoutMode ?? DEFAULT_LAYOUT_MODE) === "force";
+}
+
+export function applyGraphLayout(
+  graphData: GraphData,
+  layoutMode?: LayoutMode,
+  layoutOptions?: LayoutOptions
+): GraphData {
+  const mode = layoutMode ?? DEFAULT_LAYOUT_MODE;
+
+  if (mode === "tree") {
+    applyTreeLayout(graphData, layoutOptions?.tree);
+    pinAllNodes(graphData.nodes);
+    return graphData;
+  }
+
+  if (mode === "flow") {
+    applyFlowLayout(graphData, layoutOptions?.flow);
+    pinAllNodes(graphData.nodes);
+    return graphData;
+  }
+
+  unpinAllNodes(graphData.nodes);
+  return graphData;
+}


### PR DESCRIPTION
## Summary
- add layout mode support (`force`, `tree`, `flow`) to the canvas config API
- implement a layout engine with deterministic tree/flow positioning and non-force node pinning
- integrate layout application into data/config lifecycle and simulation handling
- update README with layout configuration documentation
- add example UI controls to select layout and direction interactively

## Validation
- npm run build
- npm run lint (passes with existing repository warnings)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three layout modes: force (live simulation), tree, and flow — switchable with persistent/pinned positions for deterministic views.
  * Layout direction options: TB, BT, LR, RL; UI selectors to choose mode and direction; changes applied immediately with zoom-to-fit for pinned layouts.
  * Example page now offers layout controls, uses a sample graph when placeholders are present, and falls back to remote loading only when configured.

* **Documentation**
  * README updated with config options, examples, and a “Layout Modes” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->