### PR TITLE
Add analysis-focused graph layout modes

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -13,6 +13,9 @@ faq
 npm
 json
 npmjs
+htmlcontent
+<htmlcontent>
+subgraph
 GitHub
 github
 config

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A standalone web component for visualizing FalkorDB graphs using force-directed 
 ## Features
 
 - 🎨 **Force-directed graph layout** - Automatic positioning using D3 force simulation with smart collision detection
-- 🧭 **Multiple layout modes** - Switch between `force`, `tree`, and `flow` graph views
+- 🧭 **Multiple layout modes** - Switch between `force`, `tree`, `flow`, `radial-tree`, `concentric`, `components`, and `arc` graph views
 - 🎯 **Interactive** - Click, hover, right-click interactions on nodes, links, and background
 - 🌓 **Theme support** - Light and dark mode compatible with customizable colors
 - ⚡ **Performance** - Optimized rendering with HTML5 canvas
@@ -138,8 +138,8 @@ function GraphVisualization() {
 | `height` | `<window height>` | Canvas height in pixels |
 | `backgroundColor` | | Background color (hex or CSS color) |
 | `foregroundColor` | | Foreground color for borders and text |
-| `layoutMode` | `force` | Layout algorithm to use: `force` \| `tree` \| `flow` |
-| `layoutOptions` | `{}` | Per-layout options. Use `tree` options (`rootNodeId`, `direction`, `levelSpacing`, `nodeSpacing`, `componentSpacing`) and `flow` options (`direction`, `layerSpacing`, `nodeSpacing`, `componentSpacing`) |
+| `layoutMode` | `force` | Layout algorithm to use: `force` \| `tree` \| `flow` \| `radial-tree` \| `concentric` \| `components` \| `arc` |
+| `layoutOptions` | `{}` | Per-layout options for each mode: `tree`, `flow`, `radialTree`, `concentric`, `components`, and `arc` |
 | `cooldownTicks` | `undefined` | Number of simulation ticks before stopping (undefined = infinite) |
 | `cooldownTime` | `1000` | Time in ms for each simulation tick |
 | `autoStopOnSettle` | `true` | Automatically stop simulation when settled |
@@ -176,18 +176,39 @@ canvas.setConfig({
   }
 });
 ```
-
-Tree layout example:
+Tree / radial tree example:
 
 ```typescript
 canvas.setConfig({
-  layoutMode: 'tree',
+  layoutMode: 'radial-tree',
   layoutOptions: {
-    tree: {
+    radialTree: {
       rootNodeId: 1,
       direction: 'TB',
-      levelSpacing: 130,
-      nodeSpacing: 110
+      radiusStep: 130
+    }
+  }
+});
+```
+
+Concentric / components / arc examples:
+
+```typescript
+canvas.setConfig({
+  layoutMode: 'concentric',
+  layoutOptions: {
+    concentric: {
+      metric: 'degree', // 'degree' | 'inDegree' | 'outDegree' | 'bfsDepth'
+      ringSpacing: 130
+    },
+    components: {
+      innerLayout: 'concentric', // 'concentric' | 'tree' | 'flow' | 'radial-tree'
+      maxColumns: 3
+    },
+    arc: {
+      direction: 'LR', // 'LR' | 'RL'
+      orderBy: 'degree', // 'id' | 'label' | 'degree'
+      curveScale: 0.22
     }
   }
 });
@@ -195,7 +216,14 @@ canvas.setConfig({
 
 Notes:
 - `force` keeps simulation enabled.
-- `tree` and `flow` pin node positions for stable deterministic views.
+- All non-`force` layouts pin node positions for stable deterministic views.
+- `components` uses its own `innerLayout` strategy for each disconnected subgraph and arranges components in a tiled view.
+- `tree`: `rootNodeId`, `direction`, `levelSpacing`, `nodeSpacing`, `componentSpacing`.
+- `flow`: `direction`, `layerSpacing`, `nodeSpacing`, `componentSpacing`.
+- `radialTree`: `rootNodeId`, `direction`, `startAngle`, `endAngle`, `radiusStep`, `componentSpacing`.
+- `concentric`: `metric`, `rootNodeId`, `ringSpacing`, `minRingNodeSpacing`, `sortWithinRing`.
+- `components`: `innerLayout`, `componentGap`, `maxColumns`, `sortComponentsBy`.
+- `arc`: `orderBy`, `direction`, `nodeSpacing`, `curveScale`.
 
 ### Data Types
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ canvas.setConfig({
 
 Notes:
 - `force` keeps simulation enabled.
-- All non-`force` layouts pin node positions for stable deterministic views.
+- All non-`force` layouts compute deterministic target positions, animate layout transitions, and support drag interactions while preserving layout structure.
 - `components` uses its own `innerLayout` strategy for each disconnected subgraph and arranges components in a tiled view.
 - `tree`: `rootNodeId`, `direction`, `levelSpacing`, `nodeSpacing`, `componentSpacing`.
 - `flow`: `direction`, `layerSpacing`, `nodeSpacing`, `componentSpacing`.

--- a/examples/falkordb-canvas.example.html
+++ b/examples/falkordb-canvas.example.html
@@ -98,6 +98,11 @@
     #selected-info {
       color: #666;
     }
+
+    #context-status {
+      color: #444;
+      margin-bottom: 12px;
+    }
   </style>
 </head>
 
@@ -107,8 +112,18 @@
 
     <div class="controls">
       <div class="control-group">
-        <button onclick="addNode()">Add Node</button>
-        <button onclick="addLink()">Add Link</button>
+        <label for="context-layer-select">Context Layer</label>
+        <select id="context-layer-select" data-context-control>
+          <option value="collaboration" selected>Collaboration Graph</option>
+          <option value="organization">Organization Graph</option>
+          <option value="geography">Geography Graph</option>
+          <option value="delivery">Delivery Graph</option>
+        </select>
+        <button onclick="expandSelectedContext()" data-context-control>Expand Layer</button>
+        <button onclick="collapseSelectedContext()" data-context-control>Collapse Layer</button>
+        <button onclick="expandAllContexts()" data-context-control>Expand All Context</button>
+        <button onclick="collapseAllContexts()" data-context-control>Collapse All Context</button>
+        <button onclick="playExpandCollapseDemo()" data-context-control>Play Expand/Collapse Demo</button>
         <button onclick="toggleLoading()">Toggle Loading</button>
       </div>
       <div class="control-group">
@@ -162,6 +177,8 @@
     </div>
 
     <div class="info">
+      <h3>Animation Context:</h3>
+      <div id="context-status">No context layers expanded yet.</div>
       <h3>Selected Element:</h3>
       <div id="selected-info">Click on a node or link to see details</div>
     </div>
@@ -189,13 +206,209 @@
 
     // Define control functions FIRST so they're available immediately for onclick handlers
     let canvas;
-    let nodeCounter = 1;
-    let linkCounter = 1;
+    let graphData = { nodes: [], links: [] };
+    let isLoading = false;
+    let isPlayingContextDemo = false;
+    const activeContextLayers = [];
     const layoutSelect = document.getElementById('layout-select');
     const layoutDirectionSelect = document.getElementById('layout-direction-select');
     const concentricMetricSelect = document.getElementById('concentric-metric-select');
     const componentsInnerLayoutSelect = document.getElementById('components-inner-layout-select');
     const arcOrderSelect = document.getElementById('arc-order-select');
+    const contextLayerSelect = document.getElementById('context-layer-select');
+    const contextStatusElement = document.getElementById('context-status');
+    const contextControls = Array.from(document.querySelectorAll('[data-context-control]'));
+
+    const SAMPLE_GRAPH_BASE_DATA = {
+      nodes: [
+        { id: 1, labels: ['Person'], color: '#FF6B6B', visible: true, data: { name: 'Alice', role: 'Engineer' } },
+        { id: 2, labels: ['Person'], color: '#4ECDC4', visible: true, data: { name: 'Bob', role: 'Engineer' } },
+        { id: 3, labels: ['Person'], color: '#45B7D1', visible: true, data: { name: 'Charlie', role: 'Engineer' } },
+        { id: 4, labels: ['Person'], color: '#FFEAA7', visible: true, data: { name: 'Dana', role: 'Tech Lead' } },
+        { id: 5, labels: ['Company'], color: '#FFA07A', visible: true, data: { name: 'FalkorDB' } },
+        { id: 6, labels: ['Product'], color: '#74B9FF', visible: true, data: { name: 'Canvas' } },
+        { id: 7, labels: ['City'], color: '#96CEB4', visible: true, data: { name: 'Tel Aviv' } },
+        { id: 8, labels: ['Project'], color: '#A29BFE', visible: true, data: { name: 'Graph Query Engine' } }
+      ],
+      links: [
+        { id: 1, relationship: 'KNOWS', color: '#888', source: 1, target: 2, visible: true, data: {} },
+        { id: 2, relationship: 'KNOWS', color: '#888', source: 2, target: 3, visible: true, data: {} },
+        { id: 3, relationship: 'KNOWS', color: '#888', source: 3, target: 4, visible: true, data: {} },
+        { id: 4, relationship: 'WORKS_AT', color: '#666', source: 1, target: 5, visible: true, data: {} },
+        { id: 5, relationship: 'WORKS_AT', color: '#666', source: 2, target: 5, visible: true, data: {} },
+        { id: 6, relationship: 'WORKS_AT', color: '#666', source: 3, target: 5, visible: true, data: {} },
+        { id: 7, relationship: 'LEADS', color: '#5D5D5D', source: 4, target: 8, visible: true, data: {} },
+        { id: 8, relationship: 'BUILDS', color: '#5D5D5D', source: 5, target: 6, visible: true, data: {} },
+        { id: 9, relationship: 'LOCATED_IN', color: '#7C7C7C', source: 5, target: 7, visible: true, data: {} },
+        { id: 10, relationship: 'CONTRIBUTES_TO', color: '#7C7C7C', source: 1, target: 6, visible: true, data: {} },
+        { id: 11, relationship: 'CONTRIBUTES_TO', color: '#7C7C7C', source: 2, target: 6, visible: true, data: {} },
+        { id: 12, relationship: 'CONTRIBUTES_TO', color: '#7C7C7C', source: 3, target: 8, visible: true, data: {} }
+      ]
+    };
+
+    const SAMPLE_GRAPH_CONTEXT_LAYERS = {
+      collaboration: {
+        label: 'Collaboration Graph',
+        nodes: [
+          { id: 101, labels: ['Person'], color: '#FD79A8', visible: true, data: { name: 'Eve', role: 'Engineer' } },
+          { id: 102, labels: ['Person'], color: '#FDCB6E', visible: true, data: { name: 'Farid', role: 'Engineer' } },
+          { id: 103, labels: ['Team'], color: '#00B894', visible: true, data: { name: 'Graph UX Guild' } },
+          { id: 104, labels: ['Project'], color: '#E17055', visible: true, data: { name: 'Query Pipeline Initiative' } }
+        ],
+        links: [
+          { id: 1001, relationship: 'KNOWS', color: '#888', source: 2, target: 101, visible: true, data: {} },
+          { id: 1002, relationship: 'KNOWS', color: '#888', source: 3, target: 102, visible: true, data: {} },
+          { id: 1003, relationship: 'MEMBER_OF', color: '#666', source: 1, target: 103, visible: true, data: {} },
+          { id: 1004, relationship: 'MEMBER_OF', color: '#666', source: 101, target: 103, visible: true, data: {} },
+          { id: 1005, relationship: 'MEMBER_OF', color: '#666', source: 102, target: 103, visible: true, data: {} },
+          { id: 1006, relationship: 'COLLABORATES_ON', color: '#5D5D5D', source: 103, target: 6, visible: true, data: {} },
+          { id: 1007, relationship: 'CONTRIBUTES_TO', color: '#5D5D5D', source: 102, target: 104, visible: true, data: {} },
+          { id: 1008, relationship: 'DEPENDS_ON', color: '#7C7C7C', source: 104, target: 8, visible: true, data: {} }
+        ]
+      },
+      organization: {
+        label: 'Organization Graph',
+        nodes: [
+          { id: 201, labels: ['Team'], color: '#6C5CE7', visible: true, data: { name: 'Platform Team' } },
+          { id: 202, labels: ['Team'], color: '#0984E3', visible: true, data: { name: 'Runtime Team' } },
+          { id: 203, labels: ['Team'], color: '#55EFC4', visible: true, data: { name: 'Observability Team' } },
+          { id: 204, labels: ['Company'], color: '#FF7675', visible: true, data: { name: 'Redwood Ventures' } }
+        ],
+        links: [
+          { id: 2001, relationship: 'HAS_TEAM', color: '#666', source: 5, target: 201, visible: true, data: {} },
+          { id: 2002, relationship: 'HAS_TEAM', color: '#666', source: 5, target: 202, visible: true, data: {} },
+          { id: 2003, relationship: 'HAS_TEAM', color: '#666', source: 5, target: 203, visible: true, data: {} },
+          { id: 2004, relationship: 'OWNS', color: '#5D5D5D', source: 201, target: 6, visible: true, data: {} },
+          { id: 2005, relationship: 'OWNS', color: '#5D5D5D', source: 202, target: 8, visible: true, data: {} },
+          { id: 2006, relationship: 'SUPPORTS', color: '#5D5D5D', source: 203, target: 8, visible: true, data: {} },
+          { id: 2007, relationship: 'PARTNERS_WITH', color: '#7C7C7C', source: 5, target: 204, visible: true, data: {} },
+          { id: 2008, relationship: 'ADVISES', color: '#7C7C7C', source: 204, target: 6, visible: true, data: {} }
+        ]
+      },
+      geography: {
+        label: 'Geography Graph',
+        nodes: [
+          { id: 301, labels: ['City'], color: '#FFD166', visible: true, data: { name: 'Berlin' } },
+          { id: 302, labels: ['Country'], color: '#06D6A0', visible: true, data: { name: 'Germany' } },
+          { id: 303, labels: ['City'], color: '#118AB2', visible: true, data: { name: 'London' } },
+          { id: 304, labels: ['Country'], color: '#073B4C', visible: true, data: { name: 'United Kingdom' } }
+        ],
+        links: [
+          { id: 3001, relationship: 'LIVES_IN', color: '#888', source: 3, target: 301, visible: true, data: {} },
+          { id: 3002, relationship: 'LOCATED_IN', color: '#666', source: 301, target: 302, visible: true, data: {} },
+          { id: 3003, relationship: 'LIVES_IN', color: '#888', source: 4, target: 303, visible: true, data: {} },
+          { id: 3004, relationship: 'LOCATED_IN', color: '#666', source: 303, target: 304, visible: true, data: {} },
+          { id: 3005, relationship: 'HAS_OFFICE_IN', color: '#5D5D5D', source: 5, target: 301, visible: true, data: {} },
+          { id: 3006, relationship: 'HAS_OFFICE_IN', color: '#5D5D5D', source: 5, target: 303, visible: true, data: {} }
+        ]
+      },
+      delivery: {
+        label: 'Delivery Graph',
+        nodes: [
+          { id: 401, labels: ['Release'], color: '#C77DFF', visible: true, data: { name: 'Canvas v0.1' } },
+          { id: 402, labels: ['Task'], color: '#7B2CBF', visible: true, data: { name: 'Layout Stress Test' } },
+          { id: 403, labels: ['Epic'], color: '#9D4EDD', visible: true, data: { name: 'Expand/Collapse Animation' } },
+          { id: 404, labels: ['Product'], color: '#90BE6D', visible: true, data: { name: 'Customer Analytics Dashboard' } }
+        ],
+        links: [
+          { id: 4001, relationship: 'DELIVERS', color: '#666', source: 6, target: 401, visible: true, data: {} },
+          { id: 4002, relationship: 'VALIDATES', color: '#5D5D5D', source: 402, target: 403, visible: true, data: {} },
+          { id: 4003, relationship: 'INCLUDES', color: '#5D5D5D', source: 401, target: 403, visible: true, data: {} },
+          { id: 4004, relationship: 'ENABLES', color: '#5D5D5D', source: 401, target: 404, visible: true, data: {} },
+          { id: 4005, relationship: 'TESTED_BY', color: '#7C7C7C', source: 402, target: 6, visible: true, data: {} },
+          { id: 4006, relationship: 'DEPENDS_ON', color: '#7C7C7C', source: 403, target: 8, visible: true, data: {} },
+          { id: 4007, relationship: 'REQUESTED_BY', color: '#7C7C7C', source: 404, target: 4, visible: true, data: {} }
+        ]
+      }
+    };
+
+    const CONTEXT_LAYER_KEYS = Object.keys(SAMPLE_GRAPH_CONTEXT_LAYERS);
+
+    const cloneGraphData = (data) => JSON.parse(JSON.stringify(data));
+
+    const setContextControlsEnabled = (enabled) => {
+      contextControls.forEach((control) => {
+        control.disabled = !enabled;
+      });
+    };
+
+    const mergeGraphDataWithContexts = (baseData, contextLayerKeys) => {
+      const nodesById = new Map();
+      const linksById = new Map();
+
+      baseData.nodes.forEach((node) => {
+        nodesById.set(node.id, { ...node });
+      });
+      baseData.links.forEach((link) => {
+        linksById.set(link.id, { ...link });
+      });
+
+      contextLayerKeys.forEach((layerKey) => {
+        const layer = SAMPLE_GRAPH_CONTEXT_LAYERS[layerKey];
+        if (!layer) return;
+
+        layer.nodes.forEach((node) => {
+          nodesById.set(node.id, { ...node });
+        });
+        layer.links.forEach((link) => {
+          linksById.set(link.id, { ...link });
+        });
+      });
+
+      return {
+        nodes: Array.from(nodesById.values()),
+        links: Array.from(linksById.values())
+      };
+    };
+
+    const updateContextStatus = (isRemoteMode) => {
+      if (!contextStatusElement) return;
+
+      if (isRemoteMode) {
+        contextStatusElement.textContent =
+          'Context expand/collapse controls are disabled when loading remote query data.';
+        return;
+      }
+
+      if (activeContextLayers.length === 0) {
+        contextStatusElement.textContent =
+          'No context layers expanded yet. Expand one to visualize transition animations.';
+        return;
+      }
+
+      const activeLabels = activeContextLayers
+        .map((layerKey) => SAMPLE_GRAPH_CONTEXT_LAYERS[layerKey]?.label)
+        .filter(Boolean);
+
+      contextStatusElement.textContent =
+        `Active context layers (${activeLabels.length}/${CONTEXT_LAYER_KEYS.length}): ${activeLabels.join(', ')}`;
+    };
+
+    const applyExpandedContexts = (isRemoteMode) => {
+      if (isRemoteMode || !canvas) return;
+
+      graphData = mergeGraphDataWithContexts(SAMPLE_GRAPH_BASE_DATA, activeContextLayers);
+      canvas.setData(cloneGraphData(graphData));
+      updateContextStatus(false);
+    };
+
+    const expandContextLayer = (layerKey, isRemoteMode) => {
+      if (isRemoteMode) return;
+      if (!SAMPLE_GRAPH_CONTEXT_LAYERS[layerKey]) return;
+      if (activeContextLayers.includes(layerKey)) return;
+
+      activeContextLayers.push(layerKey);
+      applyExpandedContexts(false);
+    };
+
+    const collapseContextLayer = (layerKey, isRemoteMode) => {
+      if (isRemoteMode) return;
+      const index = activeContextLayers.indexOf(layerKey);
+      if (index < 0) return;
+
+      activeContextLayers.splice(index, 1);
+      applyExpandedContexts(false);
+    };
 
     const updateDirectionControlState = (layoutMode) => {
       if (!layoutDirectionSelect) return;
@@ -329,53 +542,6 @@
         `Layout: ${layoutMode.toUpperCase()}${details.length > 0 ? ` (${details.join(', ')})` : ''}`;
     };
 
-    window.addNode = () => {
-      if (!canvas) {
-        alert('Graph not loaded yet, please wait...');
-        return;
-      }
-      const data = canvas.getData();
-      const colors = ['#FF6B6B', '#4ECDC4', '#45B7D1', '#FFA07A', '#96CEB4'];
-      data.nodes.push({
-        id: nodeCounter,
-        labels: ['Person'],
-        color: colors[Math.floor(Math.random() * colors.length)],
-        visible: true,
-        data: { name: `Person ${nodeCounter}` }
-      });
-      nodeCounter++;
-      canvas.setData(data);
-    };
-
-    window.addLink = () => {
-      if (!canvas) {
-        alert('Graph not loaded yet, please wait...');
-        return;
-      }
-      const data = canvas.getData();
-      if (data.nodes.length < 2) {
-        alert('Need at least 2 nodes to create a link');
-        return;
-      }
-      const sourceIdx = Math.floor(Math.random() * data.nodes.length);
-      let targetIdx = Math.floor(Math.random() * data.nodes.length);
-      while (targetIdx === sourceIdx && data.nodes.length > 1) {
-        targetIdx = Math.floor(Math.random() * data.nodes.length);
-      }
-      data.links.push({
-        id: linkCounter,
-        relationship: 'CONNECTS',
-        color: '#999',
-        source: data.nodes[sourceIdx].id,
-        target: data.nodes[targetIdx].id,
-        visible: true,
-        data: {}
-      });
-      linkCounter++;
-      canvas.setData(data);
-    };
-
-    let isLoading = false;
     window.toggleLoading = () => {
       if (!canvas) {
         alert('Graph not loaded yet, please wait...');
@@ -385,24 +551,52 @@
       canvas.setIsLoading(isLoading);
       canvas.setCooldownTicks(isLoading ? undefined : 300);
     };
+    const wait = (durationMs) =>
+      new Promise((resolve) => {
+        setTimeout(resolve, durationMs);
+      });
 
-    // Now load the graph data
-    const SAMPLE_GRAPH_DATA = {
-      nodes: [
-        { id: 1, labels: ['Person'], color: '#FF6B6B', visible: true, data: { name: 'Alice' } },
-        { id: 2, labels: ['Person'], color: '#4ECDC4', visible: true, data: { name: 'Bob' } },
-        { id: 3, labels: ['Person'], color: '#45B7D1', visible: true, data: { name: 'Charlie' } },
-        { id: 4, labels: ['Company'], color: '#FFA07A', visible: true, data: { name: 'FalkorDB' } },
-        { id: 5, labels: ['City'], color: '#96CEB4', visible: true, data: { name: 'Tel Aviv' } }
-      ],
-      links: [
-        { id: 1, relationship: 'KNOWS', color: '#888', source: 1, target: 2, visible: true, data: {} },
-        { id: 2, relationship: 'KNOWS', color: '#888', source: 2, target: 3, visible: true, data: {} },
-        { id: 3, relationship: 'WORKS_AT', color: '#666', source: 1, target: 4, visible: true, data: {} },
-        { id: 4, relationship: 'WORKS_AT', color: '#666', source: 3, target: 4, visible: true, data: {} },
-        { id: 5, relationship: 'LIVES_IN', color: '#999', source: 1, target: 5, visible: true, data: {} },
-        { id: 6, relationship: 'LIVES_IN', color: '#999', source: 2, target: 5, visible: true, data: {} }
-      ]
+    window.expandSelectedContext = () => {
+      if (!contextLayerSelect) return;
+      expandContextLayer(contextLayerSelect.value, shouldFetchRemote);
+    };
+
+    window.collapseSelectedContext = () => {
+      if (!contextLayerSelect) return;
+      collapseContextLayer(contextLayerSelect.value, shouldFetchRemote);
+    };
+
+    window.expandAllContexts = () => {
+      if (shouldFetchRemote) return;
+      activeContextLayers.splice(0, activeContextLayers.length, ...CONTEXT_LAYER_KEYS);
+      applyExpandedContexts(false);
+    };
+
+    window.collapseAllContexts = () => {
+      if (shouldFetchRemote) return;
+      activeContextLayers.length = 0;
+      applyExpandedContexts(false);
+    };
+
+    window.playExpandCollapseDemo = async () => {
+      if (shouldFetchRemote || isPlayingContextDemo) return;
+
+      isPlayingContextDemo = true;
+      try {
+        window.collapseAllContexts();
+        await wait(700);
+        expandContextLayer('collaboration', false);
+        await wait(900);
+        expandContextLayer('organization', false);
+        await wait(900);
+        expandContextLayer('geography', false);
+        await wait(900);
+        collapseContextLayer('organization', false);
+        await wait(900);
+        expandContextLayer('delivery', false);
+      } finally {
+        isPlayingContextDemo = false;
+      }
     };
 
     const API_TOKEN = 'your_api_token_here'; // Replace with your actual API token
@@ -416,7 +610,7 @@
 
     const url = `https://browser.falkordb.com/api/graph/${encodeURIComponent(graphName)}?query=${encodeURIComponent(query)}`;
 
-    let graphData = JSON.parse(JSON.stringify(SAMPLE_GRAPH_DATA));
+    graphData = cloneGraphData(SAMPLE_GRAPH_BASE_DATA);
 
     // Color palettes
     const labelColors = {};
@@ -561,6 +755,9 @@
     } else {
       console.log('Using built-in sample graph data. Set API_TOKEN/graphName/query to fetch remote data.');
     }
+    if (!shouldFetchRemote) {
+      graphData = mergeGraphDataWithContexts(SAMPLE_GRAPH_BASE_DATA, activeContextLayers);
+    }
 
     // Get the graph element
     canvas = document.getElementById('graph');
@@ -568,14 +765,16 @@
     // Wait for the element to be defined
     await customElements.whenDefined('falkordb-canvas');
 
-    // Set initial data
-    canvas.setData(graphData);
-
     const graphContainer = document.querySelector('.graph-container');
 
     // Configure the graph using individual setters (more efficient!)
     canvas.setWidth(graphContainer.clientWidth);
     canvas.setHeight(graphContainer.clientHeight);
+    setContextControlsEnabled(!shouldFetchRemote);
+    updateContextStatus(shouldFetchRemote);
+
+    // Set initial data
+    canvas.setData(cloneGraphData(graphData));
 
     // Set event handlers using setConfig (for callbacks)
     canvas.setConfig({
@@ -624,10 +823,7 @@
       updateDirectionControlState(layoutSelect.value);
     }
     window.changeLayout();
-
-    // Update counters based on loaded data
-    nodeCounter = Math.max(...graphData.nodes.map(n => n.id), 0) + 1;
-    linkCounter = Math.max(...graphData.links.map(l => l.id), 0) + 1;
+    updateContextStatus(shouldFetchRemote);
   </script>
 </body>
 

--- a/examples/falkordb-canvas.example.html
+++ b/examples/falkordb-canvas.example.html
@@ -117,6 +117,10 @@
           <option value="force" selected>Force</option>
           <option value="tree">Tree</option>
           <option value="flow">Flow</option>
+          <option value="radial-tree">Radial Tree</option>
+          <option value="concentric">Concentric</option>
+          <option value="components">Components</option>
+          <option value="arc">Arc</option>
         </select>
 
         <label for="layout-direction-select">Direction</label>
@@ -125,6 +129,30 @@
           <option value="BT">Bottom → Top</option>
           <option value="LR" selected>Left → Right</option>
           <option value="RL">Right → Left</option>
+        </select>
+      </div>
+      <div class="control-group">
+        <label for="concentric-metric-select">Concentric Metric</label>
+        <select id="concentric-metric-select" onchange="changeLayout()">
+          <option value="degree" selected>Degree</option>
+          <option value="inDegree">In Degree</option>
+          <option value="outDegree">Out Degree</option>
+          <option value="bfsDepth">BFS Depth</option>
+        </select>
+
+        <label for="components-inner-layout-select">Components Inner Layout</label>
+        <select id="components-inner-layout-select" onchange="changeLayout()">
+          <option value="concentric" selected>Concentric</option>
+          <option value="tree">Tree</option>
+          <option value="flow">Flow</option>
+          <option value="radial-tree">Radial Tree</option>
+        </select>
+
+        <label for="arc-order-select">Arc Order</label>
+        <select id="arc-order-select" onchange="changeLayout()">
+          <option value="id" selected>ID</option>
+          <option value="degree">Degree</option>
+          <option value="label">Label</option>
         </select>
       </div>
     </div>
@@ -165,16 +193,35 @@
     let linkCounter = 1;
     const layoutSelect = document.getElementById('layout-select');
     const layoutDirectionSelect = document.getElementById('layout-direction-select');
+    const concentricMetricSelect = document.getElementById('concentric-metric-select');
+    const componentsInnerLayoutSelect = document.getElementById('components-inner-layout-select');
+    const arcOrderSelect = document.getElementById('arc-order-select');
 
     const updateDirectionControlState = (layoutMode) => {
       if (!layoutDirectionSelect) return;
-      layoutDirectionSelect.disabled = layoutMode === 'force';
+      const supportsDirection =
+        layoutMode === 'tree' ||
+        layoutMode === 'flow' ||
+        layoutMode === 'radial-tree' ||
+        layoutMode === 'arc';
+
+      layoutDirectionSelect.disabled = !supportsDirection;
+      if (layoutMode === 'arc' && !['LR', 'RL'].includes(layoutDirectionSelect.value)) {
+        layoutDirectionSelect.value = 'LR';
+      }
+
+      if (concentricMetricSelect) concentricMetricSelect.disabled = layoutMode !== 'concentric';
+      if (componentsInnerLayoutSelect) componentsInnerLayoutSelect.disabled = layoutMode !== 'components';
+      if (arcOrderSelect) arcOrderSelect.disabled = layoutMode !== 'arc';
     };
 
     const getLayoutConfig = (layoutMode, direction) => {
+      const data = canvas?.getData?.();
+      const firstNodeId = data?.nodes?.[0]?.id;
+      const concentricMetric = concentricMetricSelect?.value || 'degree';
+      const componentsInnerLayout = componentsInnerLayoutSelect?.value || 'concentric';
+      const arcOrder = arcOrderSelect?.value || 'id';
       if (layoutMode === 'tree') {
-        const data = canvas?.getData?.();
-        const firstNodeId = data?.nodes?.[0]?.id;
 
         return {
           layoutMode: 'tree',
@@ -198,6 +245,53 @@
         };
       }
 
+      if (layoutMode === 'radial-tree') {
+        return {
+          layoutMode: 'radial-tree',
+          layoutOptions: {
+            radialTree: {
+              direction,
+              ...(firstNodeId !== undefined ? { rootNodeId: firstNodeId } : {})
+            }
+          }
+        };
+      }
+
+      if (layoutMode === 'concentric') {
+        return {
+          layoutMode: 'concentric',
+          layoutOptions: {
+            concentric: {
+              metric: concentricMetric,
+              ...(firstNodeId !== undefined ? { rootNodeId: firstNodeId } : {})
+            }
+          }
+        };
+      }
+
+      if (layoutMode === 'components') {
+        return {
+          layoutMode: 'components',
+          layoutOptions: {
+            components: {
+              innerLayout: componentsInnerLayout
+            }
+          }
+        };
+      }
+
+      if (layoutMode === 'arc') {
+        const arcDirection = ['LR', 'RL'].includes(direction) ? direction : 'LR';
+        return {
+          layoutMode: 'arc',
+          layoutOptions: {
+            arc: {
+              direction: arcDirection,
+              orderBy: arcOrder
+            }
+          }
+        };
+      }
       return {
         layoutMode: 'force',
         layoutOptions: {}
@@ -217,8 +311,22 @@
       }
 
       canvas.setConfig(getLayoutConfig(layoutMode, direction));
+      const details = [];
+      if (['tree', 'flow', 'radial-tree'].includes(layoutMode)) {
+        details.push(direction);
+      }
+      if (layoutMode === 'concentric') {
+        details.push(`metric=${concentricMetricSelect?.value || 'degree'}`);
+      }
+      if (layoutMode === 'components') {
+        details.push(`inner=${componentsInnerLayoutSelect?.value || 'concentric'}`);
+      }
+      if (layoutMode === 'arc') {
+        details.push(`dir=${layoutDirectionSelect.value}`);
+        details.push(`order=${arcOrderSelect?.value || 'id'}`);
+      }
       document.getElementById('selected-info').textContent =
-        `Layout: ${layoutMode.toUpperCase()}${layoutMode === 'force' ? '' : ` (${direction})`}`;
+        `Layout: ${layoutMode.toUpperCase()}${details.length > 0 ? ` (${details.join(', ')})` : ''}`;
     };
 
     window.addNode = () => {

--- a/examples/falkordb-canvas.example.html
+++ b/examples/falkordb-canvas.example.html
@@ -196,12 +196,16 @@
 
   <!-- Import the web component -->
   <script type="module">
+    let loadedFromCdnFallback = false;
     try {
-      await import('../dist/index.js');
-      console.log('Loaded local ../dist/index.js');
+      const localBuildModulePath = `../dist/index.js?v=${Date.now()}`;
+      await import(localBuildModulePath);
+      console.log('Loaded local build from', localBuildModulePath);
     } catch (error) {
+      loadedFromCdnFallback = true;
       console.warn('Falling back to CDN package because local build could not be loaded.', error);
-      await import('https://cdn.jsdelivr.net/npm/@falkordb/canvas@0.0.16/dist/index.js');
+      await import('https://cdn.jsdelivr.net/npm/@falkordb/canvas@0.0.45/dist/index.js');
+      console.warn('Loaded CDN fallback @falkordb/canvas@0.0.45. Run `npm run build` to use the local branch build.');
     }
 
     // Define control functions FIRST so they're available immediately for onclick handlers
@@ -772,6 +776,13 @@
     canvas.setHeight(graphContainer.clientHeight);
     setContextControlsEnabled(!shouldFetchRemote);
     updateContextStatus(shouldFetchRemote);
+    if (loadedFromCdnFallback) {
+      const selectedInfoElement = document.getElementById('selected-info');
+      if (selectedInfoElement) {
+        selectedInfoElement.textContent =
+          'Using CDN fallback build. If layout behavior looks outdated, run `npm run build` and refresh.';
+      }
+    }
 
     // Set initial data
     canvas.setData(cloneGraphData(graphData));

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,248 @@
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
         "eslint": "^10.0.2",
+        "jsdom": "^29.0.2",
         "tsup": "^8.5.1",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -559,6 +799,24 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -649,6 +907,317 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1000,11 +1569,40 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
       "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
     },
     "node_modules/@types/d3": {
       "version": "7.4.3",
@@ -1289,6 +1887,13 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1730,6 +2335,119 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accessor-fn": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
@@ -1786,6 +2504,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/bezier-js": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
@@ -1794,6 +2522,16 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1857,6 +2595,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1899,6 +2647,13 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1912,6 +2667,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/csstype": {
@@ -2350,6 +3119,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2368,6 +3151,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2383,6 +3173,36 @@
       "dependencies": {
         "robust-predicates": "^3.0.2"
       }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.1",
@@ -2617,6 +3437,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2625,6 +3455,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2797,6 +3637,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -2870,6 +3723,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2885,6 +3745,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -2944,6 +3845,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -2996,6 +4170,16 @@
       "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3005,6 +4189,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "10.2.4",
@@ -3054,6 +4245,25 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3070,6 +4280,17 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3121,6 +4342,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3156,9 +4390,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3188,6 +4422,35 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-load-config": {
@@ -3286,6 +4549,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -3301,6 +4574,40 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
       "license": "Unlicense"
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.126.0",
+        "@rolldown/pluginutils": "1.0.0-rc.16"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+      }
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -3359,6 +4666,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -3395,6 +4715,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -3404,6 +4731,30 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -3438,6 +4789,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3461,6 +4819,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -3475,20 +4840,76 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -3520,6 +4941,14 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -3608,6 +5037,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3616,6 +5055,232 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
+      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.16",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -3634,6 +5299,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3643,6 +5325,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "jsdom": "^29.0.2",
         "promise-retry": "2.0.1",
         "tsup": "^8.5.1",
-        "typescript": "^6.0.2",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.4"
       }
     },
@@ -5116,9 +5116,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "dev": "tsc --watch",
     "example": "python3 -m http.server 8080",
     "clean": "rm -rf dist",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run --environment jsdom",
+    "test:watch": "vitest --environment jsdom"
   },
   "repository": {
     "type": "git",
@@ -49,12 +51,14 @@
     "react": "^19.2.3"
   },
   "devDependencies": {
-    "@types/react": "^19.2.7",
     "@types/d3": "^7.4.3",
+    "@types/react": "^19.2.7",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
     "eslint": "^10.0.2",
+    "jsdom": "^29.0.2",
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint": "^10.0.2",
     "jsdom": "^29.0.2",
     "tsup": "^8.5.1",
-    "typescript": "^6.0.2",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.4"
   }
 }

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -122,6 +122,8 @@ export type GraphNode = NodeObject & {
   };
   x?: number;
   y?: number;
+  layoutTargetX?: number;
+  layoutTargetY?: number;
   vx?: number;
   vy?: number;
   fx?: number;
@@ -150,7 +152,7 @@ export interface GraphData {
 
 export type Node = Omit<
   GraphNode,
-  "x" | "y" | "vx" | "vy" | "fx" | "fy" | "initialPositionCalculated" | "displayName" | "size"
+  "x" | "y" | "layoutTargetX" | "layoutTargetY" | "vx" | "vy" | "fx" | "fy" | "initialPositionCalculated" | "displayName" | "size"
 > & {
   size?: number;
 }

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -46,9 +46,14 @@ export interface InternalForceGraphConfig extends Omit<ForceGraphConfig, 'backgr
   layoutOptions: LayoutOptions;
 }
 
-export type LayoutMode = 'force' | 'flow' | 'tree';
+export type LayoutMode = 'force' | 'flow' | 'tree' | 'radial-tree' | 'concentric' | 'components' | 'arc';
 
 export type LayoutDirection = 'TB' | 'BT' | 'LR' | 'RL';
+export type ArcDirection = 'LR' | 'RL';
+export type ConcentricMetric = 'degree' | 'inDegree' | 'outDegree' | 'bfsDepth';
+export type RingSortMode = 'id' | 'label' | 'degree';
+export type ComponentsInnerLayout = 'concentric' | 'tree' | 'flow' | 'radial-tree';
+export type ComponentsSortMode = 'size' | 'edgeCount';
 
 export interface TreeLayoutOptions {
   rootNodeId?: number;
@@ -64,10 +69,44 @@ export interface FlowLayoutOptions {
   nodeSpacing?: number;
   componentSpacing?: number;
 }
+export interface RadialTreeLayoutOptions {
+  rootNodeId?: number;
+  direction?: LayoutDirection;
+  startAngle?: number;
+  endAngle?: number;
+  radiusStep?: number;
+  componentSpacing?: number;
+}
+
+export interface ConcentricLayoutOptions {
+  metric?: ConcentricMetric;
+  rootNodeId?: number;
+  ringSpacing?: number;
+  minRingNodeSpacing?: number;
+  sortWithinRing?: RingSortMode;
+}
+
+export interface ComponentsLayoutOptions {
+  innerLayout?: ComponentsInnerLayout;
+  componentGap?: number;
+  maxColumns?: number;
+  sortComponentsBy?: ComponentsSortMode;
+}
+
+export interface ArcLayoutOptions {
+  orderBy?: RingSortMode;
+  direction?: ArcDirection;
+  nodeSpacing?: number;
+  curveScale?: number;
+}
 
 export interface LayoutOptions {
   tree?: TreeLayoutOptions;
   flow?: FlowLayoutOptions;
+  radialTree?: RadialTreeLayoutOptions;
+  concentric?: ConcentricLayoutOptions;
+  components?: ComponentsLayoutOptions;
+  arc?: ArcLayoutOptions;
 }
 
 export type GraphNode = NodeObject & {

--- a/src/canvas-utils.ts
+++ b/src/canvas-utils.ts
@@ -126,12 +126,12 @@ export function dataToGraphData(
 
 /**
  * Converts GraphData format to Data format
- * Removes runtime properties (x, y, vx, vy, fx, fy, displayName, curve)
+ * Removes runtime properties (x, y, layoutTargetX, layoutTargetY, vx, vy, fx, fy, displayName, curve)
  */
 export function graphDataToData(graphData: GraphData): Data {
   const nodes: Node[] = graphData.nodes.map((node) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { x, y, vx, vy, fx, fy, displayName, ...rest } = node;
+    const { x, y, layoutTargetX, layoutTargetY, vx, vy, fx, fy, displayName, ...rest } = node;
     return rest;
   });
 

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -41,6 +41,17 @@ const CHARGE_STRENGTH = -400;
 const CENTER_STRENGTH = 0.03;
 const VELOCITY_DECAY = 0.4;
 const ALPHA_MIN = 0.05;
+const NON_FORCE_CHARGE_STRENGTH = -220;
+const NON_FORCE_COLLIDE_PADDING = 18;
+const NON_FORCE_CENTER_STRENGTH = 0.02;
+const NON_FORCE_LINK_STRENGTH = 0.08;
+const NON_FORCE_TARGET_STRENGTH = 0.3;
+const NON_FORCE_VELOCITY_DECAY = 0.5;
+const NON_FORCE_ALPHA_MIN = 0.03;
+const NON_FORCE_LAYOUT_COOLDOWN_TICKS = 120;
+const NON_FORCE_DRAG_COOLDOWN_TICKS = 90;
+
+type NodePosition = { x: number; y: number };
 
 // Create styles for the web component
 function createStyles(backgroundColor: string, foregroundColor: string): HTMLStyleElement {
@@ -123,6 +134,8 @@ class FalkorDBCanvas extends HTMLElement {
 
   private viewport: ViewportState;
 
+  private shouldZoomToFitOnNonForceSettle: boolean = false;
+
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
@@ -200,15 +213,18 @@ class FalkorDBCanvas extends HTMLElement {
     Object.assign(this.config, config);
 
     if (layoutChanged) {
+      const previousPositions = this.getNodePositionMap();
       if (this.isForceLayoutMode() && this.config.cooldownTicks === 0 && this.data.nodes.length > 0) {
         this.config.cooldownTicks = undefined;
       }
       this.data = applyGraphLayout(this.data, this.config.layoutMode, this.config.layoutOptions);
+      const shouldAnimateNonForceLayout = this.prepareNodePositionsForCurrentLayout(previousPositions);
       if (this.graph) {
         this.calculateNodeDegree();
         this.graph.graphData(this.data);
-        this.configureSimulationForCurrentLayout();
+        this.configureSimulationForCurrentLayout(shouldAnimateNonForceLayout);
         if (this.isForceLayoutMode()) {
+          this.shouldZoomToFitOnNonForceSettle = false;
           this.config.isLoading = this.data.nodes.length > 0;
           this.config.onLoadingChange?.(this.config.isLoading);
           this.updateLoadingState();
@@ -217,9 +233,18 @@ class FalkorDBCanvas extends HTMLElement {
           this.config.onLoadingChange?.(false);
           this.updateLoadingState();
           if (this.data.nodes.length > 0) {
-            this.zoomToFit(1);
+            if (shouldAnimateNonForceLayout) {
+              this.shouldZoomToFitOnNonForceSettle = true;
+            } else {
+              this.shouldZoomToFitOnNonForceSettle = false;
+              this.zoomToFit(1);
+            }
+          } else {
+            this.shouldZoomToFitOnNonForceSettle = false;
           }
-          this.triggerRender();
+          if (!shouldAnimateNonForceLayout) {
+            this.triggerRender();
+          }
         }
       }
     }
@@ -298,11 +323,19 @@ class FalkorDBCanvas extends HTMLElement {
 
   setData(data: Data) {
     this.log('setData called with', data.nodes.length, 'nodes and', data.links.length, 'links');
-    // Convert data and apply circular layout to new nodes only
-    this.data = dataToGraphData(data);
+    const previousPositions = this.getNodePositionMap();
+    const oldNodesMap = new Map<number, GraphNode>();
+    for (const node of this.data.nodes) {
+      oldNodesMap.set(node.id, node);
+    }
+
+    // Convert data and preserve positions for existing nodes
+    this.data = dataToGraphData(data, undefined, oldNodesMap);
     this.data = applyGraphLayout(this.data, this.config.layoutMode, this.config.layoutOptions);
+    const shouldAnimateNonForceLayout = this.prepareNodePositionsForCurrentLayout(previousPositions);
 
     if (this.isForceLayoutMode()) {
+      this.shouldZoomToFitOnNonForceSettle = false;
       this.config.cooldownTicks = this.data.nodes.length > 0 ? undefined : 0;
       this.config.isLoading = this.data.nodes.length > 0;
     } else {
@@ -333,12 +366,18 @@ class FalkorDBCanvas extends HTMLElement {
     // Update graph data and properties
     this.graph
       .graphData(this.data);
-
-    this.configureSimulationForCurrentLayout();
+    this.configureSimulationForCurrentLayout(shouldAnimateNonForceLayout);
 
     if (!this.isForceLayoutMode() && this.data.nodes.length > 0) {
-      this.zoomToFit(1);
-      this.triggerRender();
+      if (shouldAnimateNonForceLayout) {
+        this.shouldZoomToFitOnNonForceSettle = true;
+      } else {
+        this.shouldZoomToFitOnNonForceSettle = false;
+        this.zoomToFit(1);
+        this.triggerRender();
+      }
+    } else {
+      this.shouldZoomToFitOnNonForceSettle = false;
     }
 
     this.updateLoadingState();
@@ -369,10 +408,13 @@ class FalkorDBCanvas extends HTMLElement {
 
   setGraphData(data: GraphData) {
     this.log('setGraphData called with', data.nodes.length, 'nodes and', data.links.length, 'links');
+    const previousPositions = this.getNodePositionMap();
     this.data = applyGraphLayout(data, this.config.layoutMode, this.config.layoutOptions);
+    const shouldAnimateNonForceLayout = this.prepareNodePositionsForCurrentLayout(previousPositions);
 
     if (this.isForceLayoutMode() && this.config.cooldownTicks === 0 && this.data.nodes.length > 0) {
       this.config.cooldownTicks = undefined;
+      this.shouldZoomToFitOnNonForceSettle = false;
     }
 
     if (!this.graph) return;
@@ -381,15 +423,22 @@ class FalkorDBCanvas extends HTMLElement {
 
     this.graph
       .graphData(this.data);
-    this.configureSimulationForCurrentLayout();
+    this.configureSimulationForCurrentLayout(shouldAnimateNonForceLayout);
 
     if (!this.isForceLayoutMode()) {
       this.config.isLoading = false;
       this.config.onLoadingChange?.(false);
       this.updateLoadingState();
       if (this.data.nodes.length > 0) {
-        this.zoomToFit(1);
-        this.triggerRender();
+        if (shouldAnimateNonForceLayout) {
+          this.shouldZoomToFitOnNonForceSettle = true;
+        } else {
+          this.shouldZoomToFitOnNonForceSettle = false;
+          this.zoomToFit(1);
+          this.triggerRender();
+        }
+      } else {
+        this.shouldZoomToFitOnNonForceSettle = false;
       }
     }
 
@@ -437,8 +486,192 @@ class FalkorDBCanvas extends HTMLElement {
   private isForceLayoutMode() {
     return isForceLayout(this.config.layoutMode);
   }
+  private getNodePositionMap(): Map<number, NodePosition> {
+    const positions = new Map<number, NodePosition>();
 
-  private configureSimulationForCurrentLayout() {
+    for (const node of this.data.nodes) {
+      if (node.x === undefined || node.y === undefined) continue;
+      positions.set(node.id, { x: node.x, y: node.y });
+    }
+
+    return positions;
+  }
+
+  private getGraphCenter(positions: Map<number, NodePosition>): NodePosition | undefined {
+    if (positions.size === 0) return undefined;
+
+    let sumX = 0;
+    let sumY = 0;
+
+    for (const position of positions.values()) {
+      sumX += position.x;
+      sumY += position.y;
+    }
+
+    return {
+      x: sumX / positions.size,
+      y: sumY / positions.size,
+    };
+  }
+
+  private getConnectedExistingPosition(
+    nodeId: number,
+    previousPositions: Map<number, NodePosition>
+  ): NodePosition | undefined {
+    let sumX = 0;
+    let sumY = 0;
+    let count = 0;
+
+    for (const link of this.data.links) {
+      const sourceId = link.source.id;
+      const targetId = link.target.id;
+
+      if (sourceId === nodeId) {
+        const existingPosition = previousPositions.get(targetId);
+        if (!existingPosition) continue;
+        sumX += existingPosition.x;
+        sumY += existingPosition.y;
+        count += 1;
+      } else if (targetId === nodeId) {
+        const existingPosition = previousPositions.get(sourceId);
+        if (!existingPosition) continue;
+        sumX += existingPosition.x;
+        sumY += existingPosition.y;
+        count += 1;
+      }
+    }
+
+    if (count === 0) return undefined;
+    return {
+      x: sumX / count,
+      y: sumY / count,
+    };
+  }
+
+  private clearLayoutTargets() {
+    for (const node of this.data.nodes) {
+      node.layoutTargetX = undefined;
+      node.layoutTargetY = undefined;
+    }
+  }
+
+  private prepareNodePositionsForCurrentLayout(previousPositions: Map<number, NodePosition>): boolean {
+    if (this.isForceLayoutMode()) {
+      this.clearLayoutTargets();
+      return false;
+    }
+
+    const graphCenter = this.getGraphCenter(previousPositions);
+    let shouldAnimate = false;
+
+    for (const node of this.data.nodes) {
+      const targetX = node.x ?? 0;
+      const targetY = node.y ?? 0;
+
+      node.layoutTargetX = targetX;
+      node.layoutTargetY = targetY;
+      node.fx = undefined;
+      node.fy = undefined;
+      node.vx = 0;
+      node.vy = 0;
+
+      if (previousPositions.size === 0) {
+        node.x = targetX;
+        node.y = targetY;
+        continue;
+      }
+
+      const previousPosition = previousPositions.get(node.id)
+        ?? this.getConnectedExistingPosition(node.id, previousPositions)
+        ?? graphCenter;
+
+      if (!previousPosition) {
+        node.x = targetX;
+        node.y = targetY;
+        continue;
+      }
+
+      node.x = previousPosition.x;
+      node.y = previousPosition.y;
+
+      if (
+        Math.abs(previousPosition.x - targetX) > 0.5
+        || Math.abs(previousPosition.y - targetY) > 0.5
+      ) {
+        shouldAnimate = true;
+      }
+    }
+
+    return shouldAnimate;
+  }
+
+  private setupAnchoredLayoutForces() {
+    if (!this.graph) return;
+
+    const linkForce = this.graph.d3Force("link");
+    if (linkForce) {
+      linkForce
+        .distance((link: GraphLink) => {
+          const sourceSize = link.source.size;
+          const targetSize = link.target.size;
+          return sourceSize + targetSize + LINK_DISTANCE * 1.6;
+        })
+        .strength(NON_FORCE_LINK_STRENGTH);
+    }
+
+    this.graph.d3Force(
+      "collide",
+      d3.forceCollide((node: GraphNode) => node.size + NON_FORCE_COLLIDE_PADDING)
+    );
+
+    this.graph.d3Force(
+      "centerX",
+      d3.forceX(0).strength(NON_FORCE_CENTER_STRENGTH)
+    );
+
+    this.graph.d3Force(
+      "centerY",
+      d3.forceY(0).strength(NON_FORCE_CENTER_STRENGTH)
+    );
+
+    this.graph.d3Force(
+      "layoutTargetX",
+      d3.forceX((node: GraphNode) => node.layoutTargetX ?? node.x ?? 0).strength(NON_FORCE_TARGET_STRENGTH)
+    );
+
+    this.graph.d3Force(
+      "layoutTargetY",
+      d3.forceY((node: GraphNode) => node.layoutTargetY ?? node.y ?? 0).strength(NON_FORCE_TARGET_STRENGTH)
+    );
+
+    const chargeForce = this.graph.d3Force("charge");
+    if (chargeForce) {
+      chargeForce.strength(NON_FORCE_CHARGE_STRENGTH);
+    }
+
+    this.graph.d3VelocityDecay(NON_FORCE_VELOCITY_DECAY);
+    this.graph.d3AlphaMin(NON_FORCE_ALPHA_MIN);
+  }
+
+  private startNonForceSettleAnimation(cooldownTicks: number) {
+    if (!this.graph || this.data.nodes.length === 0 || this.isForceLayoutMode()) return;
+
+    this.graph.cooldownTicks(cooldownTicks);
+    this.updateCanvasSimulationAttribute(true);
+    this.graph.d3ReheatSimulation();
+  }
+
+  private applyLayoutTargets() {
+    for (const node of this.data.nodes) {
+      if (node.layoutTargetX === undefined || node.layoutTargetY === undefined) continue;
+      node.x = node.layoutTargetX;
+      node.y = node.layoutTargetY;
+      node.vx = 0;
+      node.vy = 0;
+    }
+  }
+
+  private configureSimulationForCurrentLayout(shouldAnimateNonForceLayout = false) {
     if (!this.graph) return;
 
     if (this.isForceLayoutMode()) {
@@ -446,6 +679,11 @@ class FalkorDBCanvas extends HTMLElement {
       const cooldownTicks = this.config.cooldownTicks ?? Infinity;
       this.graph.cooldownTicks(cooldownTicks);
       this.updateCanvasSimulationAttribute(cooldownTicks !== 0 && this.data.nodes.length > 0);
+      return;
+    }
+    this.setupAnchoredLayoutForces();
+    if (shouldAnimateNonForceLayout) {
+      this.startNonForceSettleAnimation(NON_FORCE_LAYOUT_COOLDOWN_TICKS);
       return;
     }
 
@@ -654,6 +892,12 @@ class FalkorDBCanvas extends HTMLElement {
           this.config.onNodeHover(node);
         }
       })
+      .onNodeDrag((node: GraphNode) => {
+        this.handleNodeDrag(node);
+      })
+      .onNodeDragEnd((node: GraphNode) => {
+        this.handleNodeDragEnd(node);
+      })
       .onLinkHover((link: GraphLink | null) => {
         if (this.config.onLinkHover) {
           this.config.onLinkHover(link);
@@ -720,6 +964,9 @@ class FalkorDBCanvas extends HTMLElement {
     if (!linkForce) return;
     if (!this.graph) return;
 
+    this.graph.d3Force("layoutTargetX", null);
+    this.graph.d3Force("layoutTargetY", null);
+
     // distance based on node size + constant
     linkForce
       .distance((link: GraphLink) => {
@@ -761,6 +1008,28 @@ class FalkorDBCanvas extends HTMLElement {
       if (simulation.alphaMin) simulation.alphaMin(ALPHA_MIN);
     }
     this.log('Force simulation setup complete');
+  }
+
+  private handleNodeDrag(node: GraphNode) {
+    if (this.isForceLayoutMode()) return;
+    if (node.x === undefined || node.y === undefined) return;
+
+    node.layoutTargetX = node.x;
+    node.layoutTargetY = node.y;
+    this.shouldZoomToFitOnNonForceSettle = false;
+    this.startNonForceSettleAnimation(NON_FORCE_DRAG_COOLDOWN_TICKS);
+  }
+
+  private handleNodeDragEnd(node: GraphNode) {
+    if (this.isForceLayoutMode()) return;
+    if (node.x === undefined || node.y === undefined) return;
+
+    node.layoutTargetX = node.x;
+    node.layoutTargetY = node.y;
+    node.fx = undefined;
+    node.fy = undefined;
+    this.shouldZoomToFitOnNonForceSettle = false;
+    this.startNonForceSettleAnimation(NON_FORCE_DRAG_COOLDOWN_TICKS);
   }
 
   private drawNode(node: GraphNode, ctx: CanvasRenderingContext2D) {
@@ -1329,6 +1598,16 @@ class FalkorDBCanvas extends HTMLElement {
     if (!this.graph) return;
 
     this.log('Engine stopped');
+    if (!this.isForceLayoutMode()) {
+      this.applyLayoutTargets();
+      this.graph.cooldownTicks(0);
+      this.updateCanvasSimulationAttribute(false);
+      if (this.shouldZoomToFitOnNonForceSettle && this.data.nodes.length > 0) {
+        this.zoomToFit(1);
+      }
+      this.shouldZoomToFitOnNonForceSettle = false;
+      return;
+    }
     // If already stopped, just ensure any leftover loading state is cleared and return
     if (this.config.cooldownTicks === 0) {
       if (this.config.isLoading) {
@@ -1400,6 +1679,12 @@ class FalkorDBCanvas extends HTMLElement {
         if (this.config.onNodeHover) {
           this.config.onNodeHover(node);
         }
+      })
+      .onNodeDrag((node: GraphNode) => {
+        this.handleNodeDrag(node);
+      })
+      .onNodeDragEnd((node: GraphNode) => {
+        this.handleNodeDragEnd(node);
       })
       .onLinkHover((link: GraphLink | null) => {
         if (this.config.onLinkHover) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import FalkorDBCanvas from "./canvas.js";
 import type React from "react";
 import type {
+  ArcDirection,
   ArcLayoutOptions,
   ComponentsInnerLayout,
   ComponentsLayoutOptions,
@@ -40,6 +41,7 @@ export { FalkorDBCanvas as default, FalkorDBCanvas };
 
 // Types
 export type {
+  ArcDirection,
   CanvasRenderMode,
   LayoutMode,
   LayoutDirection,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,19 @@
 import FalkorDBCanvas from "./canvas.js";
 import type React from "react";
 import type {
+  ArcLayoutOptions,
+  ComponentsInnerLayout,
+  ComponentsLayoutOptions,
+  ComponentsSortMode,
+  ConcentricLayoutOptions,
+  ConcentricMetric,
   CanvasRenderMode,
   FlowLayoutOptions,
+  RadialTreeLayoutOptions,
   LayoutDirection,
   LayoutMode,
   LayoutOptions,
+  RingSortMode,
   TreeLayoutOptions,
 } from "./canvas-types.js";
 
@@ -38,6 +46,14 @@ export type {
   LayoutOptions,
   TreeLayoutOptions,
   FlowLayoutOptions,
+  RadialTreeLayoutOptions,
+  ConcentricLayoutOptions,
+  ComponentsLayoutOptions,
+  ArcLayoutOptions,
+  ConcentricMetric,
+  RingSortMode,
+  ComponentsInnerLayout,
+  ComponentsSortMode,
 }
 
 export type {

--- a/src/layouts.ts
+++ b/src/layouts.ts
@@ -1,22 +1,30 @@
 import * as d3 from "d3";
 import {
+  ArcLayoutOptions,
+  ComponentsInnerLayout,
+  ComponentsLayoutOptions,
+  ComponentsSortMode,
+  ConcentricLayoutOptions,
+  ConcentricMetric,
   FlowLayoutOptions,
   GraphData,
+  GraphLink,
   GraphNode,
   LayoutDirection,
   LayoutMode,
   LayoutOptions,
+  RadialTreeLayoutOptions,
+  RingSortMode,
   TreeLayoutOptions,
 } from "./canvas-types.js";
 
 type LayoutPoint = { x: number; y: number };
-
-type TreeNode = {
-  id: number;
-  children: TreeNode[];
-};
+type TreeNode = { id: number; children: TreeNode[] };
+type ComponentInfo = { nodeIds: number[]; edgeCount: number };
 
 const DEFAULT_LAYOUT_MODE: LayoutMode = "force";
+const LINK_CURVE_MULTIPLIER = 0.4;
+
 const DEFAULT_TREE_OPTIONS: Required<Omit<TreeLayoutOptions, "rootNodeId">> = {
   direction: "TB",
   levelSpacing: 130,
@@ -28,6 +36,31 @@ const DEFAULT_FLOW_OPTIONS: Required<FlowLayoutOptions> = {
   layerSpacing: 180,
   nodeSpacing: 110,
   componentSpacing: 220,
+};
+const DEFAULT_RADIAL_TREE_OPTIONS: Required<Omit<RadialTreeLayoutOptions, "rootNodeId">> = {
+  direction: "TB",
+  startAngle: -Math.PI / 2,
+  endAngle: (3 * Math.PI) / 2,
+  radiusStep: 130,
+  componentSpacing: 250,
+};
+const DEFAULT_CONCENTRIC_OPTIONS: Required<Omit<ConcentricLayoutOptions, "rootNodeId">> = {
+  metric: "degree",
+  ringSpacing: 130,
+  minRingNodeSpacing: 80,
+  sortWithinRing: "id",
+};
+const DEFAULT_COMPONENTS_OPTIONS: Required<ComponentsLayoutOptions> = {
+  innerLayout: "concentric",
+  componentGap: 260,
+  maxColumns: 3,
+  sortComponentsBy: "size",
+};
+const DEFAULT_ARC_OPTIONS: Required<ArcLayoutOptions> = {
+  orderBy: "id",
+  direction: "LR",
+  nodeSpacing: 120,
+  curveScale: 0.22,
 };
 
 function orientPoint(x: number, y: number, direction: LayoutDirection): LayoutPoint {
@@ -41,6 +74,57 @@ function orientPoint(x: number, y: number, direction: LayoutDirection): LayoutPo
     case "TB":
     default:
       return { x, y };
+  }
+}
+
+function getDirectionRotation(direction: LayoutDirection): number {
+  switch (direction) {
+    case "LR":
+      return 0;
+    case "RL":
+      return Math.PI;
+    case "BT":
+      return -Math.PI / 2;
+    case "TB":
+    default:
+      return Math.PI / 2;
+  }
+}
+
+function calculateLinkCurve(index: number, isSelfLoop: boolean): number {
+  const even = index % 2 === 0;
+
+  if (isSelfLoop) {
+    if (even) {
+      return (Math.floor(-(index / 2)) - 3) * LINK_CURVE_MULTIPLIER;
+    }
+    return (Math.floor((index + 1) / 2) + 2) * LINK_CURVE_MULTIPLIER;
+  }
+
+  if (even) {
+    return Math.floor(-(index / 2)) * LINK_CURVE_MULTIPLIER;
+  }
+  return Math.floor((index + 1) / 2) * LINK_CURVE_MULTIPLIER;
+}
+
+function resetDefaultLinkCurves(links: GraphLink[]) {
+  const linksByPairCount = new Map<number, Map<number, number>>();
+
+  for (const link of links) {
+    const sourceId = link.source.id;
+    const targetId = link.target.id;
+    const minId = Math.min(sourceId, targetId);
+    const maxId = Math.max(sourceId, targetId);
+
+    let pairMap = linksByPairCount.get(minId);
+    if (!pairMap) {
+      pairMap = new Map<number, number>();
+      linksByPairCount.set(minId, pairMap);
+    }
+
+    const duplicateIndex = pairMap.get(maxId) ?? 0;
+    pairMap.set(maxId, duplicateIndex + 1);
+    link.curve = calculateLinkCurve(duplicateIndex, sourceId === targetId);
   }
 }
 
@@ -113,7 +197,6 @@ function createAdjacency(graphData: GraphData) {
 
     const sourceOutgoing = outgoing.get(sourceId);
     const targetIncoming = incoming.get(targetId);
-
     if (!sourceOutgoing || !targetIncoming) continue;
     if (sourceOutgoing.includes(targetId)) continue;
 
@@ -122,37 +205,161 @@ function createAdjacency(graphData: GraphData) {
     inDegree.set(targetId, (inDegree.get(targetId) ?? 0) + 1);
   }
 
-  for (const ids of outgoing.values()) {
-    ids.sort((a, b) => a - b);
-  }
-
-  for (const ids of incoming.values()) {
-    ids.sort((a, b) => a - b);
-  }
+  for (const ids of outgoing.values()) ids.sort((a, b) => a - b);
+  for (const ids of incoming.values()) ids.sort((a, b) => a - b);
 
   return { nodeIds, outgoing, incoming, inDegree };
 }
 
-function applyTreeLayout(graphData: GraphData, treeOptions?: TreeLayoutOptions) {
-  const options = { ...DEFAULT_TREE_OPTIONS, ...treeOptions };
-  const { nodeIds, outgoing, inDegree } = createAdjacency(graphData);
+function getNodeMap(nodes: GraphNode[]) {
+  const nodeMap = new Map<number, GraphNode>();
+  for (const node of nodes) {
+    nodeMap.set(node.id, node);
+  }
+  return nodeMap;
+}
+
+function getNodeLabel(node: GraphNode): string {
+  const label = node.labels[0] ?? "";
+  return label || String(node.id);
+}
+
+function computeDegreeMaps(nodeIds: number[], outgoing: Map<number, number[]>, incoming: Map<number, number[]>) {
+  const inDegree = new Map<number, number>();
+  const outDegree = new Map<number, number>();
+  const degree = new Map<number, number>();
+
+  for (const id of nodeIds) {
+    const inCount = incoming.get(id)?.length ?? 0;
+    const outCount = outgoing.get(id)?.length ?? 0;
+    inDegree.set(id, inCount);
+    outDegree.set(id, outCount);
+    degree.set(id, inCount + outCount);
+  }
+
+  return { inDegree, outDegree, degree };
+}
+
+function buildUndirectedAdjacency(nodeIds: number[], outgoing: Map<number, number[]>, incoming: Map<number, number[]>) {
+  const undirected = new Map<number, number[]>();
+
+  for (const id of nodeIds) {
+    const neighbors = new Set<number>();
+    for (const target of outgoing.get(id) ?? []) neighbors.add(target);
+    for (const source of incoming.get(id) ?? []) neighbors.add(source);
+    undirected.set(id, [...neighbors].sort((a, b) => a - b));
+  }
+
+  return undirected;
+}
+
+function getDefaultRootId(
+  nodeIds: number[],
+  degreeMap: Map<number, number>,
+  preferredRootId?: number
+) {
+  if (preferredRootId !== undefined && nodeIds.includes(preferredRootId)) {
+    return preferredRootId;
+  }
+
+  let bestId = nodeIds[0];
+  let bestDegree = Number.NEGATIVE_INFINITY;
+
+  for (const nodeId of nodeIds) {
+    const nodeDegree = degreeMap.get(nodeId) ?? 0;
+    if (nodeDegree > bestDegree || (nodeDegree === bestDegree && nodeId < bestId)) {
+      bestDegree = nodeDegree;
+      bestId = nodeId;
+    }
+  }
+
+  return bestId;
+}
+
+function computeBfsDepths(
+  nodeIds: number[],
+  outgoing: Map<number, number[]>,
+  incoming: Map<number, number[]>,
+  rootId?: number
+) {
+  const undirected = buildUndirectedAdjacency(nodeIds, outgoing, incoming);
+  const degreeMap = computeDegreeMaps(nodeIds, outgoing, incoming).degree;
+  const sourceRoot = getDefaultRootId(nodeIds, degreeMap, rootId);
+  const depths = new Map<number, number>();
+  const queue: number[] = [sourceRoot];
+
+  depths.set(sourceRoot, 0);
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined) continue;
+
+    const currentDepth = depths.get(current) ?? 0;
+    for (const neighbor of undirected.get(current) ?? []) {
+      if (depths.has(neighbor)) continue;
+      depths.set(neighbor, currentDepth + 1);
+      queue.push(neighbor);
+    }
+  }
+
+  let maxDepth = 0;
+  for (const depth of depths.values()) {
+    maxDepth = Math.max(maxDepth, depth);
+  }
+
+  for (const nodeId of nodeIds) {
+    if (!depths.has(nodeId)) depths.set(nodeId, maxDepth + 1);
+  }
+
+  return depths;
+}
+
+function sortNodeIdsByMode(
+  nodeIds: number[],
+  mode: RingSortMode,
+  nodeMap: Map<number, GraphNode>,
+  degreeMap: Map<number, number>
+) {
+  const sorted = [...nodeIds];
+  sorted.sort((a, b) => {
+    if (mode === "degree") {
+      const diff = (degreeMap.get(b) ?? 0) - (degreeMap.get(a) ?? 0);
+      if (diff !== 0) return diff;
+    } else if (mode === "label") {
+      const aNode = nodeMap.get(a);
+      const bNode = nodeMap.get(b);
+      const aLabel = aNode ? getNodeLabel(aNode) : "";
+      const bLabel = bNode ? getNodeLabel(bNode) : "";
+      const labelDiff = aLabel.localeCompare(bLabel);
+      if (labelDiff !== 0) return labelDiff;
+    }
+    return a - b;
+  });
+  return sorted;
+}
+
+function buildForest(
+  nodeIds: number[],
+  outgoing: Map<number, number[]>,
+  inDegree: Map<number, number>,
+  rootNodeId?: number
+) {
   const nodeIdSet = new Set<number>(nodeIds);
+  const preferredRoots: number[] = [];
   const visited = new Set<number>();
   const forest: TreeNode[] = [];
 
-  if (nodeIds.length === 0) return;
-
-  const preferredRoots: number[] = [];
-  if (treeOptions?.rootNodeId !== undefined && nodeIdSet.has(treeOptions.rootNodeId)) {
-    preferredRoots.push(treeOptions.rootNodeId);
+  if (rootNodeId !== undefined && nodeIdSet.has(rootNodeId)) {
+    preferredRoots.push(rootNodeId);
   }
 
-  const inDegreeRoots = nodeIds.filter((nodeId) => (inDegree.get(nodeId) ?? 0) === 0);
-  for (const rootId of inDegreeRoots) {
-    if (!preferredRoots.includes(rootId)) preferredRoots.push(rootId);
+  for (const rootId of nodeIds) {
+    if ((inDegree.get(rootId) ?? 0) === 0 && !preferredRoots.includes(rootId)) {
+      preferredRoots.push(rootId);
+    }
   }
 
-  if (preferredRoots.length === 0) {
+  if (preferredRoots.length === 0 && nodeIds.length > 0) {
     preferredRoots.push(nodeIds[0]);
   }
 
@@ -181,62 +388,17 @@ function applyTreeLayout(graphData: GraphData, treeOptions?: TreeLayoutOptions) 
     forest.push(root);
   };
 
-  for (const rootId of preferredRoots) {
-    addTreeRoot(rootId);
-  }
+  for (const rootId of preferredRoots) addTreeRoot(rootId);
+  for (const nodeId of nodeIds) addTreeRoot(nodeId);
 
-  for (const nodeId of nodeIds) {
-    addTreeRoot(nodeId);
-  }
-
-  const positionByNodeId = new Map<number, LayoutPoint>();
-  let breadthOffset = 0;
-
-  for (const treeRoot of forest) {
-    const rootHierarchy = d3.hierarchy(treeRoot, (node) => node.children);
-    const treeLayout = d3
-      .tree<TreeNode>()
-      .nodeSize([options.nodeSpacing, options.levelSpacing]);
-
-    treeLayout(rootHierarchy);
-
-    let minBreadth = Number.POSITIVE_INFINITY;
-    let maxBreadth = Number.NEGATIVE_INFINITY;
-    rootHierarchy.each((node) => {
-      const breadth = node.x ?? 0;
-      minBreadth = Math.min(minBreadth, breadth);
-      maxBreadth = Math.max(maxBreadth, breadth);
-    });
-
-    rootHierarchy.each((node) => {
-      const localBreadth = (node.x ?? 0) - minBreadth + breadthOffset;
-      const localDepth = node.y ?? 0;
-      positionByNodeId.set(
-        node.data.id,
-        orientPoint(localBreadth, localDepth, options.direction)
-      );
-    });
-
-    const componentBreadth = maxBreadth - minBreadth;
-    breadthOffset += componentBreadth + options.componentSpacing;
-  }
-
-  for (const node of graphData.nodes) {
-    const position = positionByNodeId.get(node.id);
-    if (!position) continue;
-
-    node.x = position.x;
-    node.y = position.y;
-  }
-
-  centerNodePositions(graphData.nodes);
+  return forest;
 }
 
 function collectWeaklyConnectedComponents(
   nodeIds: number[],
   outgoing: Map<number, number[]>,
   incoming: Map<number, number[]>
-): number[][] {
+) {
   const visited = new Set<number>();
   const components: number[][] = [];
 
@@ -271,11 +433,40 @@ function collectWeaklyConnectedComponents(
   return components;
 }
 
+function getGraphBounds(nodes: GraphNode[]) {
+  if (nodes.length === 0) {
+    return { minX: 0, maxX: 0, minY: 0, maxY: 0, width: 0, height: 0 };
+  }
+
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (const node of nodes) {
+    const x = node.x ?? 0;
+    const y = node.y ?? 0;
+    minX = Math.min(minX, x);
+    maxX = Math.max(maxX, x);
+    minY = Math.min(minY, y);
+    maxY = Math.max(maxY, y);
+  }
+
+  return {
+    minX,
+    maxX,
+    minY,
+    maxY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+}
+
 function assignFlowLayers(
   componentNodeIds: number[],
   outgoing: Map<number, number[]>,
   incoming: Map<number, number[]>
-): Map<number, number> {
+) {
   const componentSet = new Set(componentNodeIds);
   const inDegree = new Map<number, number>();
   const layers = new Map<number, number>();
@@ -334,12 +525,102 @@ function assignFlowLayers(
   return layers;
 }
 
+function applyTreeLayout(graphData: GraphData, treeOptions?: TreeLayoutOptions) {
+  const options = { ...DEFAULT_TREE_OPTIONS, ...treeOptions };
+  const { nodeIds, outgoing, inDegree } = createAdjacency(graphData);
+  const forest = buildForest(nodeIds, outgoing, inDegree, treeOptions?.rootNodeId);
+  const positionByNodeId = new Map<number, LayoutPoint>();
+  let breadthOffset = 0;
+
+  for (const treeRoot of forest) {
+    const rootHierarchy = d3.hierarchy(treeRoot, (node) => node.children);
+    const treeLayout = d3
+      .tree<TreeNode>()
+      .nodeSize([options.nodeSpacing, options.levelSpacing]);
+
+    treeLayout(rootHierarchy);
+
+    let minBreadth = Number.POSITIVE_INFINITY;
+    let maxBreadth = Number.NEGATIVE_INFINITY;
+    rootHierarchy.each((node) => {
+      const breadth = node.x ?? 0;
+      minBreadth = Math.min(minBreadth, breadth);
+      maxBreadth = Math.max(maxBreadth, breadth);
+    });
+
+    rootHierarchy.each((node) => {
+      const localBreadth = (node.x ?? 0) - minBreadth + breadthOffset;
+      const localDepth = node.y ?? 0;
+      positionByNodeId.set(
+        node.data.id,
+        orientPoint(localBreadth, localDepth, options.direction)
+      );
+    });
+
+    const componentBreadth = maxBreadth - minBreadth;
+    breadthOffset += componentBreadth + options.componentSpacing;
+  }
+
+  for (const node of graphData.nodes) {
+    const position = positionByNodeId.get(node.id);
+    if (!position) continue;
+    node.x = position.x;
+    node.y = position.y;
+  }
+
+  centerNodePositions(graphData.nodes);
+}
+
+function applyRadialTreeLayout(graphData: GraphData, radialOptions?: RadialTreeLayoutOptions) {
+  const options = { ...DEFAULT_RADIAL_TREE_OPTIONS, ...radialOptions };
+  const { nodeIds, outgoing, inDegree } = createAdjacency(graphData);
+  const forest = buildForest(nodeIds, outgoing, inDegree, radialOptions?.rootNodeId);
+  const angleSpan = Math.max(0.001, options.endAngle - options.startAngle);
+  const rotation = getDirectionRotation(options.direction);
+  const nodeMap = getNodeMap(graphData.nodes);
+  let offsetX = 0;
+
+  for (const treeRoot of forest) {
+    const rootHierarchy = d3.hierarchy(treeRoot, (node) => node.children);
+    const treeLayout = d3.tree<TreeNode>().size([angleSpan, options.radiusStep * (rootHierarchy.height + 1)]);
+    treeLayout(rootHierarchy);
+
+    const points: Array<{ id: number; x: number; y: number }> = [];
+    rootHierarchy.each((node) => {
+      const angle = options.startAngle + (node.x ?? 0) + rotation;
+      const radius = node.y ?? 0;
+      points.push({
+        id: node.data.id,
+        x: Math.cos(angle) * radius,
+        y: Math.sin(angle) * radius,
+      });
+    });
+
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    for (const point of points) {
+      minX = Math.min(minX, point.x);
+      maxX = Math.max(maxX, point.x);
+    }
+
+    for (const point of points) {
+      const node = nodeMap.get(point.id);
+      if (!node) continue;
+      node.x = point.x - minX + offsetX;
+      node.y = point.y;
+    }
+
+    offsetX += (maxX - minX) + options.componentSpacing;
+  }
+
+  centerNodePositions(graphData.nodes);
+}
+
 function applyFlowLayout(graphData: GraphData, flowOptions?: FlowLayoutOptions) {
   const options = { ...DEFAULT_FLOW_OPTIONS, ...flowOptions };
   const { nodeIds, outgoing, incoming } = createAdjacency(graphData);
   const components = collectWeaklyConnectedComponents(nodeIds, outgoing, incoming);
   const positionByNodeId = new Map<number, LayoutPoint>();
-
   let breadthOffset = 0;
 
   for (const componentNodeIds of components) {
@@ -371,14 +652,12 @@ function applyFlowLayout(graphData: GraphData, flowOptions?: FlowLayoutOptions) 
           .map((id) => priorLayerOrder.get(id))
           .filter((index): index is number => index !== undefined);
 
-        const aScore =
-          aParents.length > 0
-            ? aParents.reduce((sum, index) => sum + index, 0) / aParents.length
-            : Number.POSITIVE_INFINITY;
-        const bScore =
-          bParents.length > 0
-            ? bParents.reduce((sum, index) => sum + index, 0) / bParents.length
-            : Number.POSITIVE_INFINITY;
+        const aScore = aParents.length > 0
+          ? aParents.reduce((sum, index) => sum + index, 0) / aParents.length
+          : Number.POSITIVE_INFINITY;
+        const bScore = bParents.length > 0
+          ? bParents.reduce((sum, index) => sum + index, 0) / bParents.length
+          : Number.POSITIVE_INFINITY;
 
         if (aScore === bScore) return a - b;
         return aScore - bScore;
@@ -409,7 +688,6 @@ function applyFlowLayout(graphData: GraphData, flowOptions?: FlowLayoutOptions) 
     for (const nodeId of componentNodeIds) {
       const basePoint = positionByNodeId.get(nodeId);
       if (!basePoint) continue;
-
       const normalizedBreadth = basePoint.x - minBreadth + breadthOffset;
       positionByNodeId.set(nodeId, { x: normalizedBreadth, y: basePoint.y });
     }
@@ -421,10 +699,238 @@ function applyFlowLayout(graphData: GraphData, flowOptions?: FlowLayoutOptions) 
   for (const node of graphData.nodes) {
     const basePoint = positionByNodeId.get(node.id);
     if (!basePoint) continue;
-
     const orientedPoint = orientPoint(basePoint.x, basePoint.y, options.direction);
     node.x = orientedPoint.x;
     node.y = orientedPoint.y;
+  }
+
+  centerNodePositions(graphData.nodes);
+}
+
+function getMetricValues(
+  metric: ConcentricMetric,
+  nodeIds: number[],
+  outgoing: Map<number, number[]>,
+  incoming: Map<number, number[]>,
+  rootNodeId?: number
+) {
+  const { degree, inDegree, outDegree } = computeDegreeMaps(nodeIds, outgoing, incoming);
+
+  if (metric === "inDegree") return inDegree;
+  if (metric === "outDegree") return outDegree;
+  if (metric === "bfsDepth") return computeBfsDepths(nodeIds, outgoing, incoming, rootNodeId);
+  return degree;
+}
+
+function applyConcentricLayout(graphData: GraphData, concentricOptions?: ConcentricLayoutOptions) {
+  const options = { ...DEFAULT_CONCENTRIC_OPTIONS, ...concentricOptions };
+  const { nodeIds, outgoing, incoming } = createAdjacency(graphData);
+  const nodeMap = getNodeMap(graphData.nodes);
+  const degreeMap = computeDegreeMaps(nodeIds, outgoing, incoming).degree;
+  const metricValues = getMetricValues(options.metric, nodeIds, outgoing, incoming, options.rootNodeId);
+  const ringByNode = new Map<number, number>();
+  const nodesByRing = new Map<number, number[]>();
+
+  if (options.metric === "bfsDepth") {
+    for (const nodeId of nodeIds) {
+      ringByNode.set(nodeId, metricValues.get(nodeId) ?? 0);
+    }
+  } else {
+    const uniqueValues = [...new Set(nodeIds.map((nodeId) => metricValues.get(nodeId) ?? 0))]
+      .sort((a, b) => b - a);
+    const ringByMetric = new Map<number, number>();
+    uniqueValues.forEach((value, index) => {
+      ringByMetric.set(value, index);
+    });
+    for (const nodeId of nodeIds) {
+      const value = metricValues.get(nodeId) ?? 0;
+      ringByNode.set(nodeId, ringByMetric.get(value) ?? 0);
+    }
+  }
+
+  for (const nodeId of nodeIds) {
+    const ring = ringByNode.get(nodeId) ?? 0;
+    const ringNodes = nodesByRing.get(ring) ?? [];
+    ringNodes.push(nodeId);
+    nodesByRing.set(ring, ringNodes);
+  }
+
+  const rings = [...nodesByRing.keys()].sort((a, b) => a - b);
+  const baseAngle = -Math.PI / 2;
+
+  for (const ring of rings) {
+    const ringNodeIds = nodesByRing.get(ring);
+    if (!ringNodeIds) continue;
+    const sortedRingNodes = sortNodeIdsByMode(ringNodeIds, options.sortWithinRing, nodeMap, degreeMap);
+    const nodeCount = sortedRingNodes.length;
+
+    let radius = ring === 0 ? 0 : ring * options.ringSpacing;
+    if (nodeCount > 1) {
+      const minRadiusForSpacing = (nodeCount * options.minRingNodeSpacing) / (2 * Math.PI);
+      radius = Math.max(radius || options.ringSpacing, minRadiusForSpacing);
+    }
+
+    sortedRingNodes.forEach((nodeId, index) => {
+      const node = nodeMap.get(nodeId);
+      if (!node) return;
+
+      if (nodeCount === 1 && ring === 0) {
+        node.x = 0;
+        node.y = 0;
+        return;
+      }
+
+      const angle = baseAngle + ((2 * Math.PI * index) / nodeCount);
+      node.x = Math.cos(angle) * radius;
+      node.y = Math.sin(angle) * radius;
+    });
+  }
+
+  centerNodePositions(graphData.nodes);
+}
+
+function applyArcLayout(graphData: GraphData, arcOptions?: ArcLayoutOptions) {
+  const options = { ...DEFAULT_ARC_OPTIONS, ...arcOptions };
+  const { nodeIds, outgoing, incoming } = createAdjacency(graphData);
+  const nodeMap = getNodeMap(graphData.nodes);
+  const degreeMap = computeDegreeMaps(nodeIds, outgoing, incoming).degree;
+  const orderedIds = sortNodeIdsByMode(nodeIds, options.orderBy, nodeMap, degreeMap);
+
+  if (options.direction === "RL") orderedIds.reverse();
+
+  const nodeIndex = new Map<number, number>();
+  orderedIds.forEach((nodeId, index) => {
+    nodeIndex.set(nodeId, index);
+    const node = nodeMap.get(nodeId);
+    if (!node) return;
+    node.x = index * options.nodeSpacing;
+    node.y = 0;
+  });
+
+  for (const link of graphData.links) {
+    const sourceIndex = nodeIndex.get(link.source.id);
+    const targetIndex = nodeIndex.get(link.target.id);
+    if (sourceIndex === undefined || targetIndex === undefined) continue;
+    if (sourceIndex === targetIndex) continue;
+
+    const distance = Math.max(1, Math.abs(sourceIndex - targetIndex));
+    const magnitude = Math.max(0.25, distance * options.curveScale);
+    link.curve = sourceIndex < targetIndex ? -magnitude : magnitude;
+  }
+
+  centerNodePositions(graphData.nodes);
+}
+
+function createComponentSubGraph(graphData: GraphData, nodeIds: number[]) {
+  const nodeIdSet = new Set<number>(nodeIds);
+  const nodes = graphData.nodes
+    .filter((node) => nodeIdSet.has(node.id))
+    .map((node) => ({ ...node }));
+  const nodeMap = new Map<number, GraphNode>();
+  for (const node of nodes) nodeMap.set(node.id, node);
+
+  const links = graphData.links
+    .filter((link) => nodeIdSet.has(link.source.id) && nodeIdSet.has(link.target.id))
+    .map((link) => ({
+      ...link,
+      source: nodeMap.get(link.source.id)!,
+      target: nodeMap.get(link.target.id)!,
+    }));
+
+  return { nodes, links } as GraphData;
+}
+
+function applyInnerComponentsLayout(
+  subGraph: GraphData,
+  innerLayout: ComponentsInnerLayout,
+  layoutOptions?: LayoutOptions
+) {
+  if (innerLayout === "flow") {
+    applyFlowLayout(subGraph, layoutOptions?.flow);
+    return;
+  }
+  if (innerLayout === "tree") {
+    applyTreeLayout(subGraph, layoutOptions?.tree);
+    return;
+  }
+  if (innerLayout === "radial-tree") {
+    applyRadialTreeLayout(subGraph, layoutOptions?.radialTree);
+    return;
+  }
+  applyConcentricLayout(subGraph, layoutOptions?.concentric);
+}
+
+function getComponentsInfo(
+  graphData: GraphData,
+  sortBy: ComponentsSortMode
+) {
+  const { nodeIds, outgoing, incoming } = createAdjacency(graphData);
+  const components = collectWeaklyConnectedComponents(nodeIds, outgoing, incoming);
+  const info: ComponentInfo[] = components.map((componentNodeIds) => {
+    const nodeSet = new Set(componentNodeIds);
+    let edgeCount = 0;
+    for (const link of graphData.links) {
+      if (nodeSet.has(link.source.id) && nodeSet.has(link.target.id)) edgeCount += 1;
+    }
+    return { nodeIds: componentNodeIds, edgeCount };
+  });
+
+  info.sort((a, b) => {
+    if (sortBy === "edgeCount") {
+      const edgeDiff = b.edgeCount - a.edgeCount;
+      if (edgeDiff !== 0) return edgeDiff;
+    }
+    const sizeDiff = b.nodeIds.length - a.nodeIds.length;
+    if (sizeDiff !== 0) return sizeDiff;
+    return a.nodeIds[0] - b.nodeIds[0];
+  });
+
+  return info;
+}
+
+function applyComponentsLayout(
+  graphData: GraphData,
+  componentsOptions?: ComponentsLayoutOptions,
+  layoutOptions?: LayoutOptions
+) {
+  const options = { ...DEFAULT_COMPONENTS_OPTIONS, ...componentsOptions };
+  const components = getComponentsInfo(graphData, options.sortComponentsBy);
+  const maxColumns = Math.max(1, options.maxColumns);
+  const globalNodeMap = getNodeMap(graphData.nodes);
+
+  let currentColumn = 0;
+  let currentX = 0;
+  let currentY = 0;
+  let rowHeight = 0;
+
+  for (const component of components) {
+    if (currentColumn >= maxColumns) {
+      currentColumn = 0;
+      currentX = 0;
+      currentY += rowHeight + options.componentGap;
+      rowHeight = 0;
+    }
+
+    const subGraph = createComponentSubGraph(graphData, component.nodeIds);
+    applyInnerComponentsLayout(subGraph, options.innerLayout, layoutOptions);
+
+    const bounds = getGraphBounds(subGraph.nodes);
+    const width = Math.max(1, bounds.width);
+    const height = Math.max(1, bounds.height);
+
+    const shiftX = currentX - bounds.minX;
+    const shiftY = currentY - bounds.minY;
+
+    for (const node of subGraph.nodes) {
+      const globalNode = globalNodeMap.get(node.id);
+      if (!globalNode) continue;
+      globalNode.x = (node.x ?? 0) + shiftX;
+      globalNode.y = (node.y ?? 0) + shiftY;
+    }
+
+    currentX += width + options.componentGap;
+    rowHeight = Math.max(rowHeight, height);
+    currentColumn += 1;
   }
 
   centerNodePositions(graphData.nodes);
@@ -438,21 +944,32 @@ export function applyGraphLayout(
   graphData: GraphData,
   layoutMode?: LayoutMode,
   layoutOptions?: LayoutOptions
-): GraphData {
+) {
   const mode = layoutMode ?? DEFAULT_LAYOUT_MODE;
+
+  if (mode !== "arc") {
+    resetDefaultLinkCurves(graphData.links);
+  }
+
+  if (mode === "force") {
+    unpinAllNodes(graphData.nodes);
+    return graphData;
+  }
 
   if (mode === "tree") {
     applyTreeLayout(graphData, layoutOptions?.tree);
-    pinAllNodes(graphData.nodes);
-    return graphData;
-  }
-
-  if (mode === "flow") {
+  } else if (mode === "flow") {
     applyFlowLayout(graphData, layoutOptions?.flow);
-    pinAllNodes(graphData.nodes);
-    return graphData;
+  } else if (mode === "radial-tree") {
+    applyRadialTreeLayout(graphData, layoutOptions?.radialTree);
+  } else if (mode === "concentric") {
+    applyConcentricLayout(graphData, layoutOptions?.concentric);
+  } else if (mode === "components") {
+    applyComponentsLayout(graphData, layoutOptions?.components, layoutOptions);
+  } else if (mode === "arc") {
+    applyArcLayout(graphData, layoutOptions?.arc);
   }
 
-  unpinAllNodes(graphData.nodes);
+  pinAllNodes(graphData.nodes);
   return graphData;
 }

--- a/src/layouts.ts
+++ b/src/layouts.ts
@@ -582,7 +582,7 @@ function applyRadialTreeLayout(graphData: GraphData, radialOptions?: RadialTreeL
 
   for (const treeRoot of forest) {
     const rootHierarchy = d3.hierarchy(treeRoot, (node) => node.children);
-    const treeLayout = d3.tree<TreeNode>().size([angleSpan, options.radiusStep * (rootHierarchy.height + 1)]);
+    const treeLayout = d3.tree<TreeNode>().size([angleSpan, options.radiusStep * rootHierarchy.height]);
     treeLayout(rootHierarchy);
 
     const points: Array<{ id: number; x: number; y: number }> = [];
@@ -806,16 +806,34 @@ function applyArcLayout(graphData: GraphData, arcOptions?: ArcLayoutOptions) {
     node.x = index * options.nodeSpacing;
     node.y = 0;
   });
+  const linksByPairCount = new Map<number, Map<number, number>>();
 
   for (const link of graphData.links) {
     const sourceIndex = nodeIndex.get(link.source.id);
     const targetIndex = nodeIndex.get(link.target.id);
     if (sourceIndex === undefined || targetIndex === undefined) continue;
-    if (sourceIndex === targetIndex) continue;
+
+    const sourceId = link.source.id;
+    const targetId = link.target.id;
+    const minId = Math.min(sourceId, targetId);
+    const maxId = Math.max(sourceId, targetId);
+    let pairMap = linksByPairCount.get(minId);
+    if (!pairMap) {
+      pairMap = new Map<number, number>();
+      linksByPairCount.set(minId, pairMap);
+    }
+    const duplicateIndex = pairMap.get(maxId) ?? 0;
+    pairMap.set(maxId, duplicateIndex + 1);
+
+    if (sourceIndex === targetIndex) {
+      link.curve = calculateLinkCurve(duplicateIndex, true);
+      continue;
+    }
 
     const distance = Math.max(1, Math.abs(sourceIndex - targetIndex));
     const magnitude = Math.max(0.25, distance * options.curveScale);
-    link.curve = sourceIndex < targetIndex ? -magnitude : magnitude;
+    const baseCurve = calculateLinkCurve(duplicateIndex, false);
+    link.curve = (sourceIndex < targetIndex ? -magnitude : magnitude) + baseCurve;
   }
 
   centerNodePositions(graphData.nodes);

--- a/tests/canvas-layout-animations.test.ts
+++ b/tests/canvas-layout-animations.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  forceGraphMockState,
+  resetForceGraphMockState,
+} from "./mocks/force-graph";
+
+vi.mock("force-graph", async () => import("./mocks/force-graph"));
+
+import "../src/canvas";
+
+type CanvasTestElement = HTMLElement & {
+  setConfig: (config: Record<string, unknown>) => void;
+  setData: (data: GraphDataInput) => void;
+  getGraphData: () => GraphDataRuntime;
+};
+
+type NodeInput = {
+  id: number;
+  labels: string[];
+  visible: boolean;
+  color: string;
+  data: Record<string, unknown>;
+};
+
+type LinkInput = {
+  id: number;
+  relationship: string;
+  source: number;
+  target: number;
+  visible: boolean;
+  color: string;
+  data: Record<string, unknown>;
+};
+
+type GraphDataInput = {
+  nodes: NodeInput[];
+  links: LinkInput[];
+};
+
+type RuntimeNode = NodeInput & {
+  x?: number;
+  y?: number;
+  layoutTargetX?: number;
+  layoutTargetY?: number;
+  fx?: number;
+  fy?: number;
+};
+
+type GraphDataRuntime = {
+  nodes: RuntimeNode[];
+  links: unknown[];
+};
+
+const NON_FORCE_LAYOUT_MODES = [
+  "tree",
+  "flow",
+  "radial-tree",
+  "concentric",
+  "components",
+  "arc",
+] as const;
+
+const NON_FORCE_LAYOUT_COOLDOWN = 120;
+const NON_FORCE_DRAG_COOLDOWN = 90;
+
+const BASE_DATA: GraphDataInput = {
+  nodes: [
+    { id: 1, labels: ["Person"], visible: true, color: "#FF6B6B", data: { name: "Alice" } },
+    { id: 2, labels: ["Person"], visible: true, color: "#4ECDC4", data: { name: "Bob" } },
+    { id: 3, labels: ["Person"], visible: true, color: "#45B7D1", data: { name: "Carol" } },
+  ],
+  links: [
+    { id: 1, relationship: "KNOWS", source: 1, target: 2, visible: true, color: "#888", data: {} },
+    { id: 2, relationship: "KNOWS", source: 2, target: 3, visible: true, color: "#777", data: {} },
+  ],
+};
+
+const EXPANDED_DATA: GraphDataInput = {
+  nodes: [
+    ...BASE_DATA.nodes,
+    { id: 4, labels: ["Person"], visible: true, color: "#FFA07A", data: { name: "Dina" } },
+  ],
+  links: [
+    ...BASE_DATA.links,
+    { id: 3, relationship: "KNOWS", source: 2, target: 4, visible: true, color: "#666", data: {} },
+  ],
+};
+
+const COLLAPSED_DATA: GraphDataInput = {
+  nodes: [
+    { id: 1, labels: ["Person"], visible: true, color: "#FF6B6B", data: { name: "Alice" } },
+    { id: 3, labels: ["Person"], visible: true, color: "#45B7D1", data: { name: "Carol" } },
+    { id: 4, labels: ["Person"], visible: true, color: "#FFA07A", data: { name: "Dina" } },
+  ],
+  links: [
+    { id: 4, relationship: "KNOWS", source: 1, target: 3, visible: true, color: "#888", data: {} },
+    { id: 5, relationship: "KNOWS", source: 3, target: 4, visible: true, color: "#666", data: {} },
+  ],
+};
+
+function cloneData(data: GraphDataInput): GraphDataInput {
+  return JSON.parse(JSON.stringify(data)) as GraphDataInput;
+}
+
+function getLastGraphMock() {
+  const instance = forceGraphMockState.lastInstance;
+  if (!instance) {
+    throw new Error("force-graph mock instance was not created");
+  }
+  return instance;
+}
+
+function getLayoutConfig(layoutMode: (typeof NON_FORCE_LAYOUT_MODES)[number]) {
+  if (layoutMode === "tree") {
+    return {
+      layoutMode,
+      layoutOptions: {
+        tree: {
+          rootNodeId: 1,
+          direction: "TB",
+        },
+      },
+    };
+  }
+
+  if (layoutMode === "flow") {
+    return {
+      layoutMode,
+      layoutOptions: {
+        flow: {
+          direction: "LR",
+        },
+      },
+    };
+  }
+
+  if (layoutMode === "radial-tree") {
+    return {
+      layoutMode,
+      layoutOptions: {
+        radialTree: {
+          rootNodeId: 1,
+          direction: "TB",
+        },
+      },
+    };
+  }
+
+  if (layoutMode === "concentric") {
+    return {
+      layoutMode,
+      layoutOptions: {
+        concentric: {
+          metric: "degree",
+          rootNodeId: 1,
+        },
+      },
+    };
+  }
+
+  if (layoutMode === "components") {
+    return {
+      layoutMode,
+      layoutOptions: {
+        components: {
+          innerLayout: "tree",
+        },
+      },
+    };
+  }
+
+  return {
+    layoutMode,
+    layoutOptions: {
+      arc: {
+        direction: "LR",
+        orderBy: "id",
+      },
+    },
+  };
+}
+
+function createCanvasElement(layoutMode: (typeof NON_FORCE_LAYOUT_MODES)[number]) {
+  const element = document.createElement("falkordb-canvas") as CanvasTestElement;
+  document.body.appendChild(element);
+  element.setConfig(getLayoutConfig(layoutMode));
+  return element;
+}
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+
+    disconnect() {}
+  }
+
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    value: ResizeObserverMock,
+    configurable: true,
+  });
+
+  Object.defineProperty(document, "fonts", {
+    value: {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(HTMLCanvasElement.prototype, "getBoundingClientRect", {
+    value: () => ({
+      width: 1000,
+      height: 600,
+      top: 0,
+      left: 0,
+      right: 1000,
+      bottom: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }),
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  resetForceGraphMockState();
+});
+
+describe.each(NON_FORCE_LAYOUT_MODES)(
+  "layout transition animations in %s mode",
+  (layoutMode) => {
+    it("animates expand and collapse updates", () => {
+      const canvas = createCanvasElement(layoutMode);
+      const graphMock = getLastGraphMock();
+
+      canvas.setData(cloneData(BASE_DATA));
+      graphMock.resetTracking();
+
+      canvas.setData(cloneData(EXPANDED_DATA));
+
+      expect(graphMock.d3ReheatSimulationCalls).toBe(1);
+      expect(graphMock.cooldownTicksValue).toBe(NON_FORCE_LAYOUT_COOLDOWN);
+      expect(graphMock.cooldownTicksHistory).toContain(NON_FORCE_LAYOUT_COOLDOWN);
+      expect(graphMock.forceMap.get("layoutTargetX")).toBeTruthy();
+      expect(graphMock.forceMap.get("layoutTargetY")).toBeTruthy();
+
+      const expandedGraph = canvas.getGraphData();
+      expect(
+        expandedGraph.nodes.every(
+          (node) => node.layoutTargetX !== undefined && node.layoutTargetY !== undefined
+        )
+      ).toBe(true);
+
+      graphMock.resetTracking();
+      canvas.setData(cloneData(COLLAPSED_DATA));
+
+      expect(graphMock.d3ReheatSimulationCalls).toBe(1);
+      expect(graphMock.cooldownTicksValue).toBe(NON_FORCE_LAYOUT_COOLDOWN);
+      expect(graphMock.cooldownTicksHistory).toContain(NON_FORCE_LAYOUT_COOLDOWN);
+
+      const collapsedGraph = canvas.getGraphData();
+      expect(
+        collapsedGraph.nodes.every(
+          (node) => node.layoutTargetX !== undefined && node.layoutTargetY !== undefined
+        )
+      ).toBe(true);
+    });
+
+    it("animates settle behavior during node drag", () => {
+      const canvas = createCanvasElement(layoutMode);
+      const graphMock = getLastGraphMock();
+
+      canvas.setData(cloneData(EXPANDED_DATA));
+      graphMock.resetTracking();
+
+      const firstNode = canvas.getGraphData().nodes[0];
+      firstNode.x = (firstNode.x ?? 0) + 48;
+      firstNode.y = (firstNode.y ?? 0) + 26;
+      graphMock.callbacks.onNodeDrag?.(firstNode, { x: 48, y: 26 });
+
+      expect(graphMock.d3ReheatSimulationCalls).toBe(1);
+      expect(graphMock.cooldownTicksValue).toBe(NON_FORCE_DRAG_COOLDOWN);
+      expect(firstNode.layoutTargetX).toBe(firstNode.x);
+      expect(firstNode.layoutTargetY).toBe(firstNode.y);
+
+      firstNode.x = (firstNode.x ?? 0) + 12;
+      firstNode.y = (firstNode.y ?? 0) + 6;
+      graphMock.callbacks.onNodeDragEnd?.(firstNode, { x: 60, y: 32 });
+
+      expect(graphMock.d3ReheatSimulationCalls).toBe(2);
+      expect(graphMock.cooldownTicksValue).toBe(NON_FORCE_DRAG_COOLDOWN);
+      expect(firstNode.layoutTargetX).toBe(firstNode.x);
+      expect(firstNode.layoutTargetY).toBe(firstNode.y);
+      expect(firstNode.fx).toBeUndefined();
+      expect(firstNode.fy).toBeUndefined();
+    });
+  }
+);

--- a/tests/mocks/force-graph.ts
+++ b/tests/mocks/force-graph.ts
@@ -1,0 +1,317 @@
+type Translate = { x: number; y: number };
+
+type CallbackMap = {
+  onNodeClick?: (node: unknown, event: MouseEvent) => void;
+  onLinkClick?: (link: unknown, event: MouseEvent) => void;
+  onNodeRightClick?: (node: unknown, event: MouseEvent) => void;
+  onLinkRightClick?: (link: unknown, event: MouseEvent) => void;
+  onNodeHover?: (node: unknown | null, previousNode: unknown | null) => void;
+  onNodeDrag?: (node: unknown, translate: Translate) => void;
+  onNodeDragEnd?: (node: unknown, translate: Translate) => void;
+  onLinkHover?: (link: unknown | null, previousLink: unknown | null) => void;
+  onBackgroundClick?: (event: MouseEvent) => void;
+  onBackgroundRightClick?: (event: MouseEvent) => void;
+  onZoom?: (transform: { k: number; x: number; y: number }) => void;
+  onEngineStop?: () => void;
+  nodePointerAreaPaint?: (node: unknown, color: string, ctx: CanvasRenderingContext2D) => void;
+  linkPointerAreaPaint?: (link: unknown, color: string, ctx: CanvasRenderingContext2D) => void;
+};
+
+class MockLinkForce {
+  public distanceAccessor: unknown;
+
+  public strengthValue: number | undefined;
+
+  distance(accessor: unknown) {
+    this.distanceAccessor = accessor;
+    return this;
+  }
+
+  strength(value: number) {
+    this.strengthValue = value;
+    return this;
+  }
+}
+
+class MockChargeForce {
+  public strengthValue: number | undefined;
+
+  strength(value: number) {
+    this.strengthValue = value;
+    return this;
+  }
+}
+
+class MockSimulationForce {
+  public velocityDecayValue: number | undefined;
+
+  public alphaMinValue: number | undefined;
+
+  velocityDecay(value: number) {
+    this.velocityDecayValue = value;
+    return this;
+  }
+
+  alphaMin(value: number) {
+    this.alphaMinValue = value;
+    return this;
+  }
+}
+
+function createDefaultForce(name: string) {
+  if (name === "link") return new MockLinkForce();
+  if (name === "charge") return new MockChargeForce();
+  if (name === "simulation") return new MockSimulationForce();
+  return undefined;
+}
+
+export class MockForceGraphInstance {
+  public callbacks: CallbackMap = {};
+
+  public data: { nodes: unknown[]; links: unknown[] } = { nodes: [], links: [] };
+
+  public cooldownTicksValue = 0;
+
+  public cooldownTicksHistory: number[] = [];
+
+  public d3ReheatSimulationCalls = 0;
+
+  public d3VelocityDecayHistory: number[] = [];
+
+  public d3AlphaMinHistory: number[] = [];
+
+  public zoomToFitCalls = 0;
+
+  public zoomToFitArgs: unknown[][] = [];
+
+  public zoomValue = 1;
+
+  public center = { x: 0, y: 0 };
+
+  public forceMap = new Map<string, unknown>();
+
+  public destroyed = false;
+
+  constructor(private readonly container: HTMLElement) {}
+
+  resetTracking() {
+    this.cooldownTicksHistory = [];
+    this.d3ReheatSimulationCalls = 0;
+    this.d3VelocityDecayHistory = [];
+    this.d3AlphaMinHistory = [];
+    this.zoomToFitCalls = 0;
+    this.zoomToFitArgs = [];
+  }
+
+  width(value?: number) {
+    if (value === undefined) return 0;
+    return this;
+  }
+
+  height(value?: number) {
+    if (value === undefined) return 0;
+    return this;
+  }
+
+  backgroundColor(value?: string) {
+    if (value === undefined) return "";
+    return this;
+  }
+
+  graphData(value?: { nodes: unknown[]; links: unknown[] }) {
+    if (value === undefined) return this.data;
+    this.data = value;
+    return this;
+  }
+
+  nodeCanvasObjectMode(_value?: unknown) { return this; }
+
+  linkCanvasObjectMode(_value?: unknown) { return this; }
+
+  nodeLabel(_value?: unknown) { return this; }
+
+  linkLabel(_value?: unknown) { return this; }
+
+  linkDirectionalArrowLength(_value?: unknown) { return this; }
+
+  linkWidth(_value?: unknown) { return this; }
+
+  linkCurvature(_value?: unknown) { return this; }
+
+  linkVisibility(_value?: unknown) { return this; }
+
+  nodeVisibility(_value?: unknown) { return this; }
+
+  cooldownTicks(value?: number) {
+    if (value === undefined) return this.cooldownTicksValue;
+    this.cooldownTicksValue = value;
+    this.cooldownTicksHistory.push(value);
+    return this;
+  }
+
+  cooldownTime(_value?: number) { return this; }
+
+  enableNodeDrag(_value?: boolean) { return this; }
+
+  enableZoomInteraction(_value?: boolean | ((event: MouseEvent) => boolean)) { return this; }
+
+  enablePanInteraction(_value?: boolean | ((event: MouseEvent) => boolean)) { return this; }
+
+  onNodeClick(callback: (node: unknown, event: MouseEvent) => void) {
+    this.callbacks.onNodeClick = callback;
+    return this;
+  }
+
+  onLinkClick(callback: (link: unknown, event: MouseEvent) => void) {
+    this.callbacks.onLinkClick = callback;
+    return this;
+  }
+
+  onNodeRightClick(callback: (node: unknown, event: MouseEvent) => void) {
+    this.callbacks.onNodeRightClick = callback;
+    return this;
+  }
+
+  onLinkRightClick(callback: (link: unknown, event: MouseEvent) => void) {
+    this.callbacks.onLinkRightClick = callback;
+    return this;
+  }
+
+  onNodeHover(callback: (node: unknown | null, previousNode: unknown | null) => void) {
+    this.callbacks.onNodeHover = callback;
+    return this;
+  }
+
+  onNodeDrag(callback: (node: unknown, translate: Translate) => void) {
+    this.callbacks.onNodeDrag = callback;
+    return this;
+  }
+
+  onNodeDragEnd(callback: (node: unknown, translate: Translate) => void) {
+    this.callbacks.onNodeDragEnd = callback;
+    return this;
+  }
+
+  onLinkHover(callback: (link: unknown | null, previousLink: unknown | null) => void) {
+    this.callbacks.onLinkHover = callback;
+    return this;
+  }
+
+  onBackgroundClick(callback: (event: MouseEvent) => void) {
+    this.callbacks.onBackgroundClick = callback;
+    return this;
+  }
+
+  onBackgroundRightClick(callback: (event: MouseEvent) => void) {
+    this.callbacks.onBackgroundRightClick = callback;
+    return this;
+  }
+
+  onZoom(callback: (transform: { k: number; x: number; y: number }) => void) {
+    this.callbacks.onZoom = callback;
+    return this;
+  }
+
+  onEngineStop(callback: () => void) {
+    this.callbacks.onEngineStop = callback;
+    return this;
+  }
+
+  nodeCanvasObject(_callback: unknown) { return this; }
+
+  linkCanvasObject(_callback: unknown) { return this; }
+
+  nodePointerAreaPaint(callback?: (node: unknown, color: string, ctx: CanvasRenderingContext2D) => void) {
+    if (!callback) return this.callbacks.nodePointerAreaPaint;
+    this.callbacks.nodePointerAreaPaint = callback;
+    return this;
+  }
+
+  linkPointerAreaPaint(callback?: (link: unknown, color: string, ctx: CanvasRenderingContext2D) => void) {
+    if (!callback) return this.callbacks.linkPointerAreaPaint;
+    this.callbacks.linkPointerAreaPaint = callback;
+    return this;
+  }
+
+  d3Force(name: string, force?: unknown) {
+    if (arguments.length > 1) {
+      this.forceMap.set(name, force);
+      return this;
+    }
+
+    if (!this.forceMap.has(name)) {
+      this.forceMap.set(name, createDefaultForce(name));
+    }
+
+    return this.forceMap.get(name);
+  }
+
+  d3VelocityDecay(value: number) {
+    this.d3VelocityDecayHistory.push(value);
+    return this;
+  }
+
+  d3AlphaMin(value: number) {
+    this.d3AlphaMinHistory.push(value);
+    return this;
+  }
+
+  d3ReheatSimulation() {
+    this.d3ReheatSimulationCalls += 1;
+    return this;
+  }
+
+  zoomToFit(...args: unknown[]) {
+    this.zoomToFitCalls += 1;
+    this.zoomToFitArgs.push(args);
+    return this;
+  }
+
+  centerAt(x?: number, y?: number, _durationMs?: number) {
+    if (x === undefined && y === undefined) return this.center;
+    if (x !== undefined) this.center.x = x;
+    if (y !== undefined) this.center.y = y;
+    return this;
+  }
+
+  zoom(value?: number, _durationMs?: number) {
+    if (value === undefined) return this.zoomValue;
+    this.zoomValue = value;
+    return this;
+  }
+
+  _destructor() {
+    this.destroyed = true;
+  }
+
+  ensureCanvasElement() {
+    let canvas = this.container.querySelector("canvas");
+    if (!canvas) {
+      canvas = document.createElement("canvas");
+      this.container.appendChild(canvas);
+    }
+  }
+}
+
+export const forceGraphMockState: {
+  instances: MockForceGraphInstance[];
+  lastInstance: MockForceGraphInstance | undefined;
+} = {
+  instances: [],
+  lastInstance: undefined,
+};
+
+export function resetForceGraphMockState() {
+  forceGraphMockState.instances = [];
+  forceGraphMockState.lastInstance = undefined;
+}
+
+const ForceGraphMockFactory = () => (container: HTMLElement) => {
+  const instance = new MockForceGraphInstance(container);
+  instance.ensureCanvasElement();
+  forceGraphMockState.instances.push(instance);
+  forceGraphMockState.lastInstance = instance;
+  return instance;
+};
+
+export default ForceGraphMockFactory;


### PR DESCRIPTION
## Summary
- add new layout modes for graph analysis: `radial-tree`, `concentric`, `components`, and `arc`
- extend layout option typing and package exports for the new modes
- implement new layout strategies and shared graph metric helpers in `src/layouts.ts`
- expand the example UI with controls for mode-specific options (concentric metric, components inner layout, arc order)
- update README documentation with the expanded layout mode/options coverage

## Validation
- npm run build
- npm run lint (passes with existing repository warnings)

## Artifacts
- Conversation: https://app.warp.dev/conversation/9406c8ec-cf8c-4b34-834e-432ae839590a
- Plan: https://app.warp.dev/drive/notebook/5VUE9fFGrrUBrf5RaExj2Z

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four layout modes: radial-tree, concentric, components, arc; non-force layouts now produce deterministic targets, animate transitions, and support drag-driven settle.
  * Example app: new animation-context layer UI with per-layer expand/collapse, demo play, and updated layout selectors.

* **Documentation**
  * README expanded with per-mode option tables and new examples for all layouts.

* **Tests**
  * Added animation/drag-settle tests and a comprehensive force-graph mock.

* **Chores**
  * Added Vitest test scripts and dev deps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->