### PR TITLE
ci: move publish workflow to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       # Ensure npm 11.5.1 or later is installed


### PR DESCRIPTION
## Summary
- switch publish workflow Node runtime from 22 to 24
- avoid the Node 22.22.2/npm self-upgrade failure during npm publish

## Scope
- only updates .github/workflows/publish.yml

Co-Authored-By: Oz <oz-agent@warp.dev>