### PR TITLE
feat: add optional borderColor to GraphNode and use default canvas co…

### DIFF
--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -382,6 +382,8 @@ export type GraphNode = NodeObject & {
   displayName: [string, string];
   /** Fill color for the node circle (CSS color string) */
   color: string;
+  /** Border stroke color for the node (CSS color string, optional — overrides config.borderColor if set) */
+  borderColor?: string;
   /** Radius of the node circle in world units */
   size: number;
   /** Arbitrary key-value properties on the node (used for label resolution via captionsKeys) */

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -382,7 +382,7 @@ export type GraphNode = NodeObject & {
   displayName: [string, string];
   /** Fill color for the node circle (CSS color string) */
   color: string;
-  /** Border stroke color for the node (CSS color string, optional — overrides config.borderColor if set) */
+  /** Border stroke color for the node (CSS color string, optional — overrides config.foregroundColor if set) */
   borderColor?: string;
   /** Radius of the node circle in world units */
   size: number;

--- a/src/canvas-utils.ts
+++ b/src/canvas-utils.ts
@@ -87,9 +87,11 @@ export function dataToGraphData(
         oldNode.expand = [node.expand ?? false, new Date()];
       }
       // Always sync mutable fields so callers can update color, visibility, borderColor,
-      // and arbitrary data (e.g. isPath / isPathSelected) without losing position.
+      // size, labels, and arbitrary data (e.g. isPath / isPathSelected) without losing position.
+      oldNode.labels = node.labels ?? oldNode.labels;
+      oldNode.size = node.size ?? oldNode.size;
       oldNode.color = node.color ?? oldNode.color;
-      oldNode.borderColor = node.borderColor;
+      oldNode.borderColor = node.borderColor ?? oldNode.borderColor;
       oldNode.visible = node.visible ?? oldNode.visible;
       oldNode.data = node.data ?? oldNode.data;
 

--- a/src/canvas-utils.ts
+++ b/src/canvas-utils.ts
@@ -7,6 +7,12 @@ import {
   GraphLink,
 } from "./canvas-types.js";
 
+/** Default canvas background color */
+export const DEFAULT_CANVAS_BACKGROUND = '#FFFFFF';
+
+/** Default canvas foreground color (text, node labels, etc.) */
+export const DEFAULT_CANVAS_FOREGROUND = '#1A1A1A';
+
 /** Default link distance between connected nodes (world units) */
 export const LINK_DISTANCE = 45;
 /** Default node circle radius (world units) */
@@ -80,10 +86,16 @@ export function dataToGraphData(
       if (oldNode.expand[0] !== (node.expand ?? false)) {
         oldNode.expand = [node.expand ?? false, new Date()];
       }
+      // Always sync mutable fields so callers can update color, visibility, borderColor,
+      // and arbitrary data (e.g. isPath / isPathSelected) without losing position.
+      oldNode.color = node.color ?? oldNode.color;
+      oldNode.borderColor = node.borderColor;
+      oldNode.visible = node.visible ?? oldNode.visible;
+      oldNode.data = node.data ?? oldNode.data;
 
       return oldNode;
     }
-    
+
     return {
       ...node,
       size: node.size ?? NODE_SIZE,

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -21,6 +21,8 @@ import {
 } from "./canvas-types.js";
 import {
   dataToGraphData,
+  DEFAULT_CANVAS_BACKGROUND,
+  DEFAULT_CANVAS_FOREGROUND,
   getContrastTextColor,
   getNodeDisplayText,
   graphDataToData,
@@ -167,8 +169,8 @@ class FalkorDBCanvas extends HTMLElement {
 
   private config: InternalForceGraphConfig = {
     // ─── Dimensions & Colors ─────────────────────────────────────────────────
-    backgroundColor: '#FFFFFF',
-    foregroundColor: '#1A1A1A',
+    backgroundColor: DEFAULT_CANVAS_BACKGROUND,
+    foregroundColor: DEFAULT_CANVAS_FOREGROUND,
 
     // ─── Layout ──────────────────────────────────────────────────────────────
     layoutMode: "force",
@@ -185,7 +187,8 @@ class FalkorDBCanvas extends HTMLElement {
     captionsKeys: [],
     showPropertyKeyPrefix: false,
     pinOnDragEnd: false,
-  };
+    dimmed: false,
+  } as InternalForceGraphConfig;
 
   private nodeMode: CanvasRenderMode = 'replace';
 
@@ -1331,7 +1334,7 @@ class FalkorDBCanvas extends HTMLElement {
     }
 
     ctx.lineWidth = this.config.isNodeSelected?.(node) ? this.config.nodeStyle.strokeWidthSelected : this.config.nodeStyle.strokeWidthUnselected;
-    ctx.strokeStyle = this.config.foregroundColor;
+    ctx.strokeStyle = node.borderColor ?? this.config.foregroundColor;
     ctx.fillStyle = node.color;
 
     const radius = node.size + ctx.lineWidth / 2;


### PR DESCRIPTION
…lors in FalkorDBCanvas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for per-node border colors, allowing individual nodes to override the default border stroke.
  * Introduced shared default canvas colors for background and node/text foreground.
* **Bug Fixes**
  * Improved refresh behavior so reused nodes properly update labels, size, color, border color, visibility, and associated data.
  * Canvas rendering now uses consistent default styling and starts explicitly in a non-dimmed state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->