### PR TITLE
fix: improve zoom calculation to prevent over-zooming for small node …

### DIFF
--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -936,7 +936,15 @@ class FalkorDBCanvas extends HTMLElement {
       const padding = minDimension * this.config.interaction.zoomToFitPadding;
       const availableW = Math.max(rect.width - 2 * padding, 0);
       const availableH = Math.max(rect.height - 2 * padding, 0);
-      zoom = Math.min(availableW / worldWidth, availableH / worldHeight);
+      
+      // For small node sets, add minimum padding to prevent over-zoom
+      // Ensure effective world dimensions have at least 15% padding on each side
+      const minWorldW = availableW * 0.7;
+      const minWorldH = availableH * 0.7;
+      const effectiveWorldW = Math.max(worldWidth, minWorldW);
+      const effectiveWorldH = Math.max(worldHeight, minWorldH);
+      
+      zoom = Math.min(availableW / effectiveWorldW, availableH / effectiveWorldH);
     }
 
     // Apply the caller-supplied multiplier then clamp to the configured max

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -937,14 +937,19 @@ class FalkorDBCanvas extends HTMLElement {
       const availableW = Math.max(rect.width - 2 * padding, 0);
       const availableH = Math.max(rect.height - 2 * padding, 0);
       
-      // For small node sets, add minimum padding to prevent over-zoom
-      // Ensure effective world dimensions have at least 15% padding on each side
+      // Cap effective world dimensions to prevent over-zoom on small node sets.
+      // When the bounding box is tiny relative to the viewport, the effective dimensions
+      // are floored to 70% of the available viewport, limiting auto-zoom to ~1.43x
+      // (availableViewport / (0.7 * availableViewport) = 1/0.7 ≈ 1.43).
       const minWorldW = availableW * 0.7;
       const minWorldH = availableH * 0.7;
       const effectiveWorldW = Math.max(worldWidth, minWorldW);
       const effectiveWorldH = Math.max(worldHeight, minWorldH);
-      
+
       zoom = Math.min(availableW / effectiveWorldW, availableH / effectiveWorldH);
+      // Guard against NaN when both the canvas dimension and the world dimension are 0
+      // (e.g., a hidden canvas combined with all nodes sharing the same coordinate axis).
+      if (!isFinite(zoom)) zoom = maxZoom;
     }
 
     // Apply the caller-supplied multiplier then clamp to the configured max

--- a/tests/canvas-api.test.ts
+++ b/tests/canvas-api.test.ts
@@ -7,9 +7,10 @@ import {
 vi.mock("force-graph", async () => import("./mocks/force-graph"));
 
 import "../src/canvas";
-import type { CanvasTestElement } from "./test-types";
+import type { CanvasTestElement, GraphNode } from "./test-types";
 
 type CanvasElement = CanvasTestElement;
+type RuntimeNode = GraphNode;
 
 beforeAll(() => {
   class ResizeObserverMock {
@@ -383,7 +384,7 @@ describe("zoomToFit with filter", () => {
     resetForceGraphMockState();
   });
 
-  it("calls force-graph zoomToFit with filter function", () => {
+  it("calls force-graph zoom with filter function", () => {
     const canvas = createCanvas();
     canvas.setConfig({ width: 800, height: 600 });
     canvas.setData(SIMPLE_DATA);
@@ -394,7 +395,8 @@ describe("zoomToFit with filter", () => {
     const filter = (node: unknown) => (node as RuntimeNode).id === 1;
     canvas.zoomToFit(1, filter);
 
-    expect(instance.zoomToFitCalls).toBe(1);
+    // Single node after filter → worldWidth = worldHeight = 0 → zoom clamps to maxZoom=8
+    expect(instance.zoomValue).toBe(8);
   });
 
   it("uses default padding multiplier", () => {
@@ -406,7 +408,9 @@ describe("zoomToFit with filter", () => {
     instance.resetTracking();
 
     canvas.zoomToFit();
-    expect(instance.zoomToFitCalls).toBe(1);
+    // Nodes have coordinates from circular layout so the custom zoom path is taken
+    expect(instance.zoomValue).toBeGreaterThan(0);
+    expect(isFinite(instance.zoomValue)).toBe(true);
   });
 });
 

--- a/tests/canvas-config.test.ts
+++ b/tests/canvas-config.test.ts
@@ -344,12 +344,12 @@ describe("setConfig immediate application", () => {
     const instance = getLastInstance();
     instance.resetTracking();
 
-    // zoomToFit hasn't fired yet
-    expect(instance.zoomToFitCalls).toBe(0);
+    // Auto-zoom hasn't fired yet — zoomValue is still the initial mock default
+    expect(instance.zoomValue).toBe(1);
 
-    // Advance past the delay
+    // Advance past the delay — custom zoom path calls graph.zoom(), not graph.zoomToFit()
     vi.advanceTimersByTime(200);
-    expect(instance.zoomToFitCalls).toBeGreaterThan(0);
+    expect(instance.zoomValue).not.toBe(1);
     vi.useRealTimers();
   });
 

--- a/tests/canvas-viewport.test.ts
+++ b/tests/canvas-viewport.test.ts
@@ -151,24 +151,54 @@ describe("viewport methods", () => {
     expect(instance.zoomValue).toBe(3);
   });
 
-  it("zoomToFit calls underlying force-graph method", () => {
+  it("zoomToFit applies computed zoom to the force-graph instance", () => {
     const canvas = createCanvas();
     canvas.setConfig({ width: 800, height: 600 });
     canvas.setData(SIMPLE_DATA);
 
     canvas.zoomToFit(1);
     const instance = getLastInstance();
-    expect(instance.zoomToFitCalls).toBe(1);
+    // Nodes have coordinates from circular layout so the custom zoom path is taken;
+    // zoom() is called on the instance (not the fallback zoomToFit()).
+    expect(instance.zoomValue).toBeGreaterThan(0);
+    expect(isFinite(instance.zoomValue)).toBe(true);
   });
 
-  it("zoomToFit with default parameters", () => {
+  it("zoomToFit with default parameters applies computed zoom", () => {
     const canvas = createCanvas();
     canvas.setConfig({ width: 800, height: 600 });
     canvas.setData(SIMPLE_DATA);
 
     canvas.zoomToFit();
     const instance = getLastInstance();
-    expect(instance.zoomToFitCalls).toBe(1);
+    expect(instance.zoomValue).toBeGreaterThan(0);
+    expect(isFinite(instance.zoomValue)).toBe(true);
+  });
+
+  it("zoomToFit caps zoom for small bounding boxes when nodes have coordinates", () => {
+    // Canvas: 800x600, zoomToFitPadding=0.1 → padding=60, availableW=680, availableH=480
+    // Nodes placed 10 world-units apart (tiny bounding box).
+    // Without the effective-world-dim cap:  zoom = min(680/10, 480/10) = 48, clamped to maxZoom=8.
+    // With the cap (floor at 70% of available viewport):
+    //   effectiveWorldW = max(10, 476) = 476,  effectiveWorldH = max(10, 336) = 336
+    //   zoom = min(680/476, 480/336) ≈ 1.43
+    const canvas = createCanvas();
+    canvas.setConfig({ width: 800, height: 600 });
+    canvas.setData(SIMPLE_DATA);
+
+    const instance = getLastInstance();
+    const graphData = (canvas as any).getGraphData();
+    graphData.nodes[0].x = 0;
+    graphData.nodes[0].y = 0;
+    graphData.nodes[1].x = 10;
+    graphData.nodes[1].y = 10;
+
+    canvas.zoomToFit(1);
+
+    // zoom should be capped to ~1.43, not the uncapped ~48 or maxZoom=8
+    expect(instance.zoomValue).toBeCloseTo(1.43, 1);
+    // The fallback force-graph zoomToFit should NOT have been called
+    expect(instance.zoomToFitCalls).toBe(0);
   });
 });
 


### PR DESCRIPTION
…sets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “fit to view” zoom calculations to prevent excessive zoom-in when the diagram (or filtered selection) has a very small bounding box.
  * Added safeguards so the computed zoom remains valid (finite and positive) and applies the corrected zoom directly rather than relying on the underlying fitter in edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->