### PR TITLE
fix: revert node version to 22 and specify npm version in publish wor…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,11 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '24'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      # Ensure npm 11.5.1 or later is installed
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
       - run: npm ci
       - name: Set version from Git tag
         run: |


### PR DESCRIPTION
…kflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release/publish automation to use a supported Node.js version and a fixed npm version for more consistent publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->