### PR TITLE
chore(deps): ignore TypeScript 7.0.x in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
       npm-minor-patch:
         update-types:
           - "patch"
+    ignore:
+      # TypeScript 7.0 (native Go compiler) ships no JS Compiler API and its
+      # peer range is rejected by @typescript-eslint (ERESOLVE), so bumping
+      # typescript to 7.0.x breaks install/build. Scoped to 7.0.x only:
+      # TypeScript 7.1 is expected to restore the programmatic API, so allow
+      # Dependabot to propose 7.1+ when it lands.
+      - dependency-name: "typescript"
+        versions: ["7.0.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` rule for the `typescript` **7.0.x** line (npm ecosystem). Scoped to 7.0.x only — **7.1+ is intentionally allowed**.

## Why

TypeScript 7.0 is the new native (Go) compiler rewrite. It ships no JavaScript **Compiler API** at the package root, and its peer range is rejected by `@typescript-eslint`. Bumping `typescript` to 7.0.x therefore fails the install with an `npm ERESOLVE` conflict:

```
npm error Found: typescript@7.0.2
npm error Conflicting peer dependency: typescript@6.0.3
npm error   peer typescript@">=4.8.4 <6.1.0" from @typescript-eslint/eslint-plugin@8.63.0
```

This is exactly what breaks **#162** (Dependabot `typescript 6.0.3 → 7.0.2`), failing the `build` job.

## Why 7.0.x only (not 7.x)

**TypeScript 7.1** is expected to restore the programmatic JS Compiler API. Scoping the ignore to `7.0.x` lets Dependabot propose **7.1+** once it lands (CI will then verify compatibility), rather than blocking the entire major line. 6.x patch/minor updates are unaffected.

Note: #162 can be closed once this merges — Dependabot will stop re-proposing the 7.0.x bump.