### PR TITLE
feat: add optional link style overrides for width, font size, and arrow size

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,8 @@ Configuration is passed to `setConfig()` as a `ForceGraphConfig` object. It is o
 | Option | Default | Description |
 |--------|---------|-------------|
 | `fontFamily` | `'SofiaSans'` | Font family for link labels |
-| `fontSize` | `2` | Font size for link labels (world units) |
 | `fontWeightUnselected` | `400` | Font weight when not selected |
 | `fontWeightSelected` | `700` | Font weight when selected |
-| `lineWidthSelected` | `2` | Line width when selected |
-| `lineWidthUnselected` | `1` | Line width when not selected |
-| `arrowLengthSelected` | `16` | Arrow length when selected |
-| `arrowLengthUnselected` | `8` | Arrow length when not selected |
 | `arrowWidthRatio` | `1.6` | Arrow width-to-height ratio |
 | `arrowNotchRatio` | `0.2` | Arrow notch depth ratio |
 | `selfLoopCurveFactor` | `11.67` | Self-loop curve factor |
@@ -300,10 +295,13 @@ Notes:
 | `source` | *required* | Source node ID |
 | `target` | *required* | Target node ID |
 | `visible` | *required* | Whether the link is visible |
-| `width` | `1` | Line width override (before dividing by zoom scale) |
-| `fontSize` | `2` | Relationship caption font size override (world units) |
-| `arrowSize` | `8` | Arrowhead length override |
+| `width` | `1` | Line width (before dividing by zoom scale) |
+| `fontSize` | `6` | Relationship caption font size (world units) |
+| `arrowSize` | `8` | Arrowhead length |
 | `data` | *required* | Link properties as key-value pairs |
+
+`width` and `arrowSize` are doubled while the link is selected, so selected
+links stay visually distinct.
 
 #### GraphNode
 Internal format with computed properties:

--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ Notes:
 | `source` | *required* | Source node ID |
 | `target` | *required* | Target node ID |
 | `visible` | *required* | Whether the link is visible |
-| `width` | `1` | Line width (before dividing by zoom scale) |
+| `width` | `1` | Line width in screen pixels (stays constant while zooming) |
 | `fontSize` | `6` | Relationship caption font size (world units) |
-| `arrowSize` | `8` | Arrowhead length |
+| `arrowSize` | `8` | Arrowhead length (world units) |
 | `data` | *required* | Link properties as key-value pairs |
 
 `width` and `arrowSize` are doubled while the link is selected, so selected

--- a/README.md
+++ b/README.md
@@ -300,6 +300,9 @@ Notes:
 | `source` | *required* | Source node ID |
 | `target` | *required* | Target node ID |
 | `visible` | *required* | Whether the link is visible |
+| `width` | `1` | Line width override (before dividing by zoom scale) |
+| `fontSize` | `2` | Relationship caption font size override (world units) |
+| `arrowSize` | `8` | Arrowhead length override |
 | `data` | *required* | Link properties as key-value pairs |
 
 #### GraphNode

--- a/examples/falkordb-canvas.example.html
+++ b/examples/falkordb-canvas.example.html
@@ -545,10 +545,6 @@
               <label>Font</label>
               <input type="text" id="ls-fontFamily" value="SofiaSans" style="width: 90px;">
             </div>
-            <div class="field">
-              <label>Size</label>
-              <input type="number" id="ls-fontSize" value="2" min="0.5" max="8" step="0.5">
-            </div>
           </div>
           <div class="field-row">
             <div class="field">
@@ -558,26 +554,6 @@
             <div class="field">
               <label>Weight (selected)</label>
               <input type="number" id="ls-fontWeightSelected" value="700" min="100" max="900" step="100">
-            </div>
-          </div>
-          <div class="field-row">
-            <div class="field">
-              <label>Line (normal)</label>
-              <input type="number" id="ls-lineWidthUnselected" value="1" min="0.25" max="10" step="0.25">
-            </div>
-            <div class="field">
-              <label>Line (selected)</label>
-              <input type="number" id="ls-lineWidthSelected" value="2" min="0.5" max="10" step="0.5">
-            </div>
-          </div>
-          <div class="field-row">
-            <div class="field">
-              <label>Arrow (normal)</label>
-              <input type="number" id="ls-arrowLengthUnselected" value="8" min="0" max="40" step="2">
-            </div>
-            <div class="field">
-              <label>Arrow (selected)</label>
-              <input type="number" id="ls-arrowLengthSelected" value="16" min="0" max="40" step="2">
             </div>
           </div>
           <div class="field-row">
@@ -842,13 +818,8 @@
       <table>
         <tr><th>Property</th><th>Type</th><th>Default</th><th>Description</th></tr>
         <tr><td><code>fontFamily</code></td><td>string</td><td>'SofiaSans'</td><td>Font for link labels</td></tr>
-        <tr><td><code>fontSize</code></td><td>number</td><td>2</td><td>Label font size</td></tr>
         <tr><td><code>fontWeightUnselected</code></td><td>number</td><td>400</td><td>Weight (normal)</td></tr>
         <tr><td><code>fontWeightSelected</code></td><td>number</td><td>700</td><td>Weight (selected)</td></tr>
-        <tr><td><code>lineWidthSelected</code></td><td>number</td><td>2</td><td>Thickness (selected)</td></tr>
-        <tr><td><code>lineWidthUnselected</code></td><td>number</td><td>1</td><td>Thickness (normal)</td></tr>
-        <tr><td><code>arrowLengthSelected</code></td><td>number</td><td>16</td><td>Arrow length (selected)</td></tr>
-        <tr><td><code>arrowLengthUnselected</code></td><td>number</td><td>8</td><td>Arrow length (normal)</td></tr>
         <tr><td><code>arrowWidthRatio</code></td><td>number</td><td>1.6</td><td>Arrow width/height ratio</td></tr>
         <tr><td><code>arrowNotchRatio</code></td><td>number</td><td>0.2</td><td>Arrow notch depth</td></tr>
         <tr><td><code>selfLoopCurveFactor</code></td><td>number</td><td>11.67</td><td>Self-loop curvature</td></tr>
@@ -1158,13 +1129,8 @@
       canvas.setConfig({
         linkStyle: {
           fontFamily: document.getElementById('ls-fontFamily').value,
-          fontSize: parseFloat(document.getElementById('ls-fontSize').value),
           fontWeightUnselected: parseInt(document.getElementById('ls-fontWeightUnselected').value),
           fontWeightSelected: parseInt(document.getElementById('ls-fontWeightSelected').value),
-          lineWidthSelected: parseFloat(document.getElementById('ls-lineWidthSelected').value),
-          lineWidthUnselected: parseFloat(document.getElementById('ls-lineWidthUnselected').value),
-          arrowLengthSelected: parseFloat(document.getElementById('ls-arrowLengthSelected').value),
-          arrowLengthUnselected: parseFloat(document.getElementById('ls-arrowLengthUnselected').value),
           arrowWidthRatio: parseFloat(document.getElementById('ls-arrowWidthRatio').value),
           arrowNotchRatio: parseFloat(document.getElementById('ls-arrowNotchRatio').value),
           selfLoopCurveFactor: parseFloat(document.getElementById('ls-selfLoopCurveFactor').value),

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -426,6 +426,12 @@ export type GraphLink = {
   visible: boolean;
   /** Stroke color for the link line (CSS color string) */
   color: string;
+  /** Optional line width override (before dividing by globalScale). Defaults to linkStyle.lineWidth{Selected,Unselected} */
+  width?: number;
+  /** Optional label font size override in world units. Defaults to linkStyle.fontSize */
+  fontSize?: number;
+  /** Optional arrowhead length override. Defaults to linkStyle.arrowLength{Selected,Unselected} */
+  arrowSize?: number;
   /** Curvature value for parallel edges and self-loops */
   curve: number;
   /** Arbitrary key-value properties on the link */

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -43,20 +43,10 @@ export interface NodeStyleConfig {
 export interface LinkStyleConfig {
   /** Font family for link labels. Default: 'SofiaSans' */
   fontFamily?: string;
-  /** Font size for link labels (world units). Default: 2 */
-  fontSize?: number;
   /** Font weight when link is not selected. Default: 400 */
   fontWeightUnselected?: number;
   /** Font weight when link is selected. Default: 700 */
   fontWeightSelected?: number;
-  /** Line width when selected (before dividing by globalScale). Default: 2 */
-  lineWidthSelected?: number;
-  /** Line width when not selected (before dividing by globalScale). Default: 1 */
-  lineWidthUnselected?: number;
-  /** Arrow length when selected. Default: 16 */
-  arrowLengthSelected?: number;
-  /** Arrow length when not selected. Default: 8 */
-  arrowLengthUnselected?: number;
   /** Arrow width-to-height ratio. Default: 1.6 */
   arrowWidthRatio?: number;
   /** Arrow notch depth ratio. Default: 0.2 */
@@ -426,11 +416,11 @@ export type GraphLink = {
   visible: boolean;
   /** Stroke color for the link line (CSS color string) */
   color: string;
-  /** Optional line width override (before dividing by globalScale). Defaults to linkStyle.lineWidth{Selected,Unselected} */
+  /** Line width before dividing by globalScale. Default: LINK_WIDTH. Doubled while the link is selected */
   width?: number;
-  /** Optional label font size override in world units. Defaults to linkStyle.fontSize */
+  /** Label font size in world units. Default: LINK_FONT_SIZE */
   fontSize?: number;
-  /** Optional arrowhead length override. Defaults to linkStyle.arrowLength{Selected,Unselected} */
+  /** Arrowhead length. Default: ARROW_SIZE. Doubled while the link is selected */
   arrowSize?: number;
   /** Curvature value for parallel edges and self-loops */
   curve: number;

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -416,11 +416,11 @@ export type GraphLink = {
   visible: boolean;
   /** Stroke color for the link line (CSS color string) */
   color: string;
-  /** Line width before dividing by globalScale. Default: LINK_WIDTH. Doubled while the link is selected */
+  /** Line width in screen pixels (divided by globalScale, so it stays constant while zooming). Default: LINK_WIDTH. Doubled while the link is selected */
   width?: number;
-  /** Label font size in world units. Default: LINK_FONT_SIZE */
+  /** Label font size in world units (scales with zoom). Default: LINK_FONT_SIZE */
   fontSize?: number;
-  /** Arrowhead length. Default: ARROW_SIZE. Doubled while the link is selected */
+  /** Arrowhead length in world units (scales with zoom). Default: ARROW_SIZE. Doubled while the link is selected */
   arrowSize?: number;
   /** Curvature value for parallel edges and self-loops */
   curve: number;

--- a/src/canvas-utils.ts
+++ b/src/canvas-utils.ts
@@ -17,6 +17,12 @@ export const DEFAULT_CANVAS_FOREGROUND = '#1A1A1A';
 export const LINK_DISTANCE = 45;
 /** Default node circle radius (world units) */
 export const NODE_SIZE = 9;
+/** Default link line width (before dividing by globalScale) */
+export const LINK_WIDTH = 1;
+/** Default link label font size (world units) */
+export const LINK_FONT_SIZE = 2;
+/** Default link arrowhead length */
+export const ARROW_SIZE = 8;
 const DEFAULT_LINK_CURVE_MULTIPLIER = 0.4;
 
 type NodePair = [number, number];

--- a/src/canvas-utils.ts
+++ b/src/canvas-utils.ts
@@ -17,11 +17,11 @@ export const DEFAULT_CANVAS_FOREGROUND = '#1A1A1A';
 export const LINK_DISTANCE = 45;
 /** Default node circle radius (world units) */
 export const NODE_SIZE = 9;
-/** Default link line width (before dividing by globalScale) */
+/** Default link line width, in screen pixels (divided by globalScale so it stays constant while zooming) */
 export const LINK_WIDTH = 1;
-/** Default link label font size (world units) */
+/** Default link label font size (world units — scales with zoom) */
 export const LINK_FONT_SIZE = 6;
-/** Default link arrowhead length */
+/** Default link arrowhead length (world units — scales with zoom) */
 export const ARROW_SIZE = 8;
 const DEFAULT_LINK_CURVE_MULTIPLIER = 0.4;
 

--- a/src/canvas-utils.ts
+++ b/src/canvas-utils.ts
@@ -20,7 +20,7 @@ export const NODE_SIZE = 9;
 /** Default link line width (before dividing by globalScale) */
 export const LINK_WIDTH = 1;
 /** Default link label font size (world units) */
-export const LINK_FONT_SIZE = 2;
+export const LINK_FONT_SIZE = 6;
 /** Default link arrowhead length */
 export const ARROW_SIZE = 8;
 const DEFAULT_LINK_CURVE_MULTIPLIER = 0.4;

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -1284,7 +1284,9 @@ class FalkorDBCanvas extends HTMLElement {
    * For straight / quadratic-bezier links the test uses the convex-hull bounding
    * box of (source, control point, target), which is always a conservative
    * (never-false-negative) bound.  For self-loops the test uses a square of
-   * side ≈ the loop diameter centred on the node.
+   * side ≈ the loop diameter centred on the node.  Both are grown by the link's
+   * visual extent (arrowhead / label) so a large per-link `arrowSize` or
+   * `fontSize` never gets culled while still partly on screen.
    */
   private isLinkInCullingBounds(link: GraphLink): boolean {
     if (!this.cullingBounds) return true;
@@ -1295,11 +1297,18 @@ class FalkorDBCanvas extends HTMLElement {
     const ex = link.target.x ?? 0;
     const ey = link.target.y ?? 0;
 
+    // Visual extent beyond the pure link geometry: the arrowhead sticks out
+    // along the curve and the label is drawn around its midpoint.
+    const margin = Math.max(
+      (link.arrowSize ?? ARROW_SIZE) * LINK_SELECTED_SCALE,
+      link.fontSize ?? LINK_FONT_SIZE,
+    );
+
     if (link.source.id === link.target.id) {
       // Self-loop: the cubic bezier extends roughly |curve| * nodeSize * factor
       // away from the node centre. Use that as a conservative radius.
       const nodeSize = link.source.size;
-      const loopRadius = Math.abs(link.curve || 1) * nodeSize * this.config.linkStyle.selfLoopCurveFactor;
+      const loopRadius = Math.abs(link.curve || 1) * nodeSize * this.config.linkStyle.selfLoopCurveFactor + margin;
       return (
         sx + loopRadius >= minX && sx - loopRadius <= maxX &&
         sy + loopRadius >= minY && sy - loopRadius <= maxY
@@ -1312,7 +1321,7 @@ class FalkorDBCanvas extends HTMLElement {
     const distance = Math.sqrt(dx * dx + dy * dy);
     if (distance === 0) {
       // Co-located nodes: just check the point.
-      return sx >= minX && sx <= maxX && sy >= minY && sy <= maxY;
+      return sx + margin >= minX && sx - margin <= maxX && sy + margin >= minY && sy - margin <= maxY;
     }
 
     const curvature = link.curve ?? 0;
@@ -1321,11 +1330,11 @@ class FalkorDBCanvas extends HTMLElement {
     const cx = (sx + ex) / 2 + perpX * curvature * distance;
     const cy = (sy + ey) / 2 + perpY * curvature * distance;
 
-    // Convex-hull AABB of the three control points.
-    const lMinX = Math.min(sx, ex, cx);
-    const lMaxX = Math.max(sx, ex, cx);
-    const lMinY = Math.min(sy, ey, cy);
-    const lMaxY = Math.max(sy, ey, cy);
+    // Convex-hull AABB of the three control points, grown by the visual margin.
+    const lMinX = Math.min(sx, ex, cx) - margin;
+    const lMaxX = Math.max(sx, ex, cx) + margin;
+    const lMinY = Math.min(sy, ey, cy) - margin;
+    const lMaxY = Math.max(sy, ey, cy) + margin;
 
     return lMaxX >= minX && lMinX <= maxX && lMaxY >= minY && lMinY <= maxY;
   }

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -36,6 +36,9 @@ import { isForceLayout, pinAllNodes, unpinAllNodes, computeTreePositions, comput
 
 const PADDING = 2;
 
+/** Selected links are drawn this many times wider, with a proportionally larger arrowhead. */
+const LINK_SELECTED_SCALE = 2;
+
 // ─── Default Sub-Configs ───────────────────────────────────────────────────────
 
 const DEFAULT_NODE_STYLE: Required<NodeStyleConfig> = {
@@ -55,13 +58,8 @@ const DEFAULT_NODE_STYLE: Required<NodeStyleConfig> = {
 
 const DEFAULT_LINK_STYLE: Required<LinkStyleConfig> = {
   fontFamily: 'SofiaSans',
-  fontSize: LINK_FONT_SIZE,
   fontWeightUnselected: 400,
   fontWeightSelected: 700,
-  lineWidthSelected: LINK_WIDTH * 2,
-  lineWidthUnselected: LINK_WIDTH,
-  arrowLengthSelected: ARROW_SIZE * 2,
-  arrowLengthUnselected: ARROW_SIZE,
   arrowWidthRatio: 1.6,
   arrowNotchRatio: 0.2,
   selfLoopCurveFactor: 11.67,
@@ -1524,11 +1522,12 @@ class FalkorDBCanvas extends HTMLElement {
     let angle;
 
     const isLinkSelected = this.config.isLinkSelected?.(link) ?? false;
-    // Per-link overrides (link.arrowSize / link.width / link.fontSize) take
-    // precedence over the shared linkStyle config, mirroring node.size.
-    const arrowLen = link.arrowSize ?? (isLinkSelected ? this.config.linkStyle.arrowLengthSelected : this.config.linkStyle.arrowLengthUnselected);
-    const lineWidth = link.width ?? (isLinkSelected ? this.config.linkStyle.lineWidthSelected : this.config.linkStyle.lineWidthUnselected);
-    const fontSize = link.fontSize ?? this.config.linkStyle.fontSize;
+    // Link sizes live on the link itself (mirroring node.size); a selected link
+    // is drawn at double width/arrow size so selection stays visible.
+    const emphasis = isLinkSelected ? LINK_SELECTED_SCALE : 1;
+    const arrowLen = (link.arrowSize ?? ARROW_SIZE) * emphasis;
+    const lineWidth = (link.width ?? LINK_WIDTH) * emphasis;
+    const fontSize = link.fontSize ?? LINK_FONT_SIZE;
 
     // Low-zoom flags – evaluated once per link draw.
     // lowZoomThreshold is the zoom level below which details are hidden (e.g. 0.5 = skip at half zoom).
@@ -1554,48 +1553,57 @@ class FalkorDBCanvas extends HTMLElement {
       const nodeStrokeWidth = this.config.isNodeSelected?.(start) ? this.config.nodeStyle.strokeWidthSelected : this.config.nodeStyle.strokeWidthUnselected;
       const borderRadius = nodeSize + nodeStrokeWidth + this.edgeGap;
 
-      // Binary search for tArrow near 1.0 where the curve is at distance borderRadius
-      // from the node center (i.e. on the outer edge of the node border stroke).
-      // Bezier parametric form: Bx(t)=sx+3(1-t)t²d, By(t)=sy-3(1-t)²td
-      // dist(t) = 3*(1-t)*t*|d|*sqrt(t² + (1-t)²)
+      // Binary search for t near 1.0 where the curve is at the given distance
+      // from the node center. Bezier parametric form:
+      // Bx(t)=sx+3(1-t)t²d, By(t)=sy-3(1-t)²td
+      // dist(t) = 3*(1-t)*t*|d|*sqrt(t² + (1-t)²), monotonically decreasing on [0.5, 1].
       const arrowHalfWidth = arrowLen / this.config.linkStyle.arrowWidthRatio / 2;
-      let lo = 0.5, hi = 1.0;
       const absD = Math.abs(d);
-      // Max reachable distance in [0.5, 1.0] is ≈ 0.53 * |d| (at t = 0.5).
-      // If |d| is too small to reach borderRadius, skip the arrowhead entirely.
-      const maxReachableDist = 3 * 0.5 * 0.5 * absD * Math.sqrt(0.5);
-      const canReachBorder = absD > 0 && maxReachableDist >= borderRadius;
-      if (canReachBorder) {
+      const solveT = (targetDist: number) => {
+        let lo = 0.5, hi = 1.0;
         for (let i = 0; i < 20; i++) {
           const mid = (lo + hi) / 2;
           const um = 1 - mid;
           const dist = 3 * um * mid * absD * Math.sqrt(mid * mid + um * um);
-          if (dist > borderRadius) lo = mid;
+          if (dist > targetDist) lo = mid;
           else hi = mid;
         }
-      }
-      const tArrow = (lo + hi) / 2;
+        return (lo + hi) / 2;
+      };
+      // Max reachable distance in [0.5, 1.0] is ≈ 0.53 * |d| (at t = 0.5).
+      // If |d| is too small to reach borderRadius, skip the arrowhead entirely.
+      const maxReachableDist = 3 * 0.5 * 0.5 * absD * Math.sqrt(0.5);
+      const canReachBorder = absD > 0 && maxReachableDist >= borderRadius;
+      const tArrow = canReachBorder ? solveT(borderRadius) : 0.75;
       const uArrow = 1 - tArrow;
       const tipX = start.x + 3 * uArrow * tArrow * tArrow * d;
       const tipY = start.y - 3 * uArrow * uArrow * tArrow * d;
+
+      // Stop the stroke at the arrowhead notch so the line never shows through
+      // the arrow tip.
+      const arrowBack = skipArrows ? 0 : arrowLen * (1 - this.config.linkStyle.arrowNotchRatio);
+      const tLine = canReachBorder ? solveT(borderRadius + arrowBack) : tArrow;
+      const uLine = 1 - tLine;
+      const lineEndX = start.x + 3 * uLine * tLine * tLine * d;
+      const lineEndY = start.y - 3 * uLine * uLine * tLine * d;
 
       ctx.strokeStyle = link.color;
       ctx.beginPath();
       ctx.moveTo(start.x, start.y);
       if (canReachBorder) {
-        // Clip the bezier stroke at tArrow using De Casteljau subdivision so
-        // the stroke stops exactly at the arrowhead tip and does not continue
-        // through it. Split control points for the [0, tArrow] segment:
-        //   CP1 = (sx,              sy - tArrow*d)
-        //   CP2 = (sx + tArrow²*d,  sy - 2*tArrow*(1-tArrow)*d)
-        //   End = B(tArrow) = (tipX, tipY)
+        // Clip the bezier stroke at tLine using De Casteljau subdivision so the
+        // stroke stops at the arrowhead base and does not continue through it.
+        // Split control points for the [0, tLine] segment:
+        //   CP1 = (sx,             sy - tLine*d)
+        //   CP2 = (sx + tLine²*d,  sy - 2*tLine*(1-tLine)*d)
+        //   End = B(tLine) = (lineEndX, lineEndY)
         ctx.bezierCurveTo(
           start.x,
-          start.y - tArrow * d,
-          start.x + tArrow * tArrow * d,
-          start.y - 2 * tArrow * uArrow * d,
-          tipX,
-          tipY,
+          start.y - tLine * d,
+          start.x + tLine * tLine * d,
+          start.y - 2 * tLine * uLine * d,
+          lineEndX,
+          lineEndY,
         );
       } else {
         // d is too small to reach the node border — draw the full self-loop
@@ -1687,6 +1695,14 @@ class FalkorDBCanvas extends HTMLElement {
       const tipX = uArrow * uArrow * start.x + 2 * uArrow * tArrow * controlX + tArrow * tArrow * end.x;
       const tipY = uArrow * uArrow * start.y + 2 * uArrow * tArrow * controlY + tArrow * tArrow * end.y;
 
+      // Stop the stroke at the arrowhead notch so the line never shows through
+      // the arrow tip.
+      const arrowBack = skipArrows ? 0 : arrowLen * (1 - this.config.linkStyle.arrowNotchRatio);
+      const tLine = Math.max(0.5, 1 - (borderRadius + arrowBack) / (2 * ctrlEndDist));
+      const uLine = 1 - tLine;
+      const lineEndX = uLine * uLine * start.x + 2 * uLine * tLine * controlX + tLine * tLine * end.x;
+      const lineEndY = uLine * uLine * start.y + 2 * uLine * tLine * controlY + tLine * tLine * end.y;
+
       // Source-side clip: place edge start at srcBorderRadius from node center
       const startNodeSize = start.size;
       const srcBorderRadius = startNodeSize + (this.config.isNodeSelected?.(start) ? 1 : 0.5) + this.edgeGap;
@@ -1701,14 +1717,14 @@ class FalkorDBCanvas extends HTMLElement {
       const gapStartX = uS * uS * start.x + 2 * uS * tStart * controlX + tStart * tStart * end.x;
       const gapStartY = uS * uS * start.y + 2 * uS * tStart * controlY + tStart * tStart * end.y;
 
-      // Sub-bezier [tStart, tArrow] control point via De Casteljau:
+      // Sub-bezier [tStart, tLine] control point via De Casteljau:
       //   Right sub-bezier at tStart → NewP1 = lerp(control, end, tStart)
-      //   Left sub-curve at tArrow' = (tArrow-tStart)/(1-tStart) → ctrl = lerp(gapStart, NewP1, tArrow')
-      const tArrowPrime = tStart < tArrow ? (tArrow - tStart) / (1 - tStart) : 0;
+      //   Left sub-curve at tLine' = (tLine-tStart)/(1-tStart) → ctrl = lerp(gapStart, NewP1, tLine')
+      const tLinePrime = tStart < tLine ? (tLine - tStart) / (1 - tStart) : 0;
       const newP1X = (1 - tStart) * controlX + tStart * end.x;
       const newP1Y = (1 - tStart) * controlY + tStart * end.y;
-      const subCtrlX = (1 - tArrowPrime) * gapStartX + tArrowPrime * newP1X;
-      const subCtrlY = (1 - tArrowPrime) * gapStartY + tArrowPrime * newP1Y;
+      const subCtrlX = (1 - tLinePrime) * gapStartX + tLinePrime * newP1X;
+      const subCtrlY = (1 - tLinePrime) * gapStartY + tLinePrime * newP1Y;
 
       ctx.strokeStyle = link.color;
       ctx.lineWidth = lineWidth / globalScale;
@@ -1716,7 +1732,7 @@ class FalkorDBCanvas extends HTMLElement {
       ctx.setLineDash(this.config.linkLineDash?.(link) ?? []);
       ctx.beginPath();
       ctx.moveTo(gapStartX, gapStartY);
-      ctx.quadraticCurveTo(subCtrlX, subCtrlY, tipX, tipY);
+      ctx.quadraticCurveTo(subCtrlX, subCtrlY, lineEndX, lineEndY);
       ctx.stroke();
       ctx.setLineDash([]);
 

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -21,12 +21,15 @@ import {
 } from "./canvas-types.js";
 import {
   dataToGraphData,
+  ARROW_SIZE,
   DEFAULT_CANVAS_BACKGROUND,
   DEFAULT_CANVAS_FOREGROUND,
   getContrastTextColor,
   getNodeDisplayText,
   graphDataToData,
   LINK_DISTANCE,
+  LINK_FONT_SIZE,
+  LINK_WIDTH,
   wrapTextForCircularNode,
 } from "./canvas-utils.js";
 import { isForceLayout, pinAllNodes, unpinAllNodes, computeTreePositions, computeRadialPositions } from "./layouts.js";
@@ -52,13 +55,13 @@ const DEFAULT_NODE_STYLE: Required<NodeStyleConfig> = {
 
 const DEFAULT_LINK_STYLE: Required<LinkStyleConfig> = {
   fontFamily: 'SofiaSans',
-  fontSize: 2,
+  fontSize: LINK_FONT_SIZE,
   fontWeightUnselected: 400,
   fontWeightSelected: 700,
-  lineWidthSelected: 2,
-  lineWidthUnselected: 1,
-  arrowLengthSelected: 16,
-  arrowLengthUnselected: 8,
+  lineWidthSelected: LINK_WIDTH * 2,
+  lineWidthUnselected: LINK_WIDTH,
+  arrowLengthSelected: ARROW_SIZE * 2,
+  arrowLengthUnselected: ARROW_SIZE,
   arrowWidthRatio: 1.6,
   arrowNotchRatio: 0.2,
   selfLoopCurveFactor: 11.67,
@@ -1521,7 +1524,11 @@ class FalkorDBCanvas extends HTMLElement {
     let angle;
 
     const isLinkSelected = this.config.isLinkSelected?.(link) ?? false;
-    const arrowLen = isLinkSelected ? this.config.linkStyle.arrowLengthSelected : this.config.linkStyle.arrowLengthUnselected;
+    // Per-link overrides (link.arrowSize / link.width / link.fontSize) take
+    // precedence over the shared linkStyle config, mirroring node.size.
+    const arrowLen = link.arrowSize ?? (isLinkSelected ? this.config.linkStyle.arrowLengthSelected : this.config.linkStyle.arrowLengthUnselected);
+    const lineWidth = link.width ?? (isLinkSelected ? this.config.linkStyle.lineWidthSelected : this.config.linkStyle.lineWidthUnselected);
+    const fontSize = link.fontSize ?? this.config.linkStyle.fontSize;
 
     // Low-zoom flags – evaluated once per link draw.
     // lowZoomThreshold is the zoom level below which details are hidden (e.g. 0.5 = skip at half zoom).
@@ -1539,7 +1546,7 @@ class FalkorDBCanvas extends HTMLElement {
       const nodeSize = start.size;
       const d = (link.curve || 0) * nodeSize * this.config.linkStyle.selfLoopCurveFactor;
 
-      ctx.lineWidth = (isLinkSelected ? this.config.linkStyle.lineWidthSelected : this.config.linkStyle.lineWidthUnselected) / globalScale;
+      ctx.lineWidth = lineWidth / globalScale;
       if (this.config.linkLineDash) ctx.setLineDash(this.config.linkLineDash(link));
 
       // The visible outer edge of the node border is nodeSize + strokeWidth
@@ -1704,7 +1711,7 @@ class FalkorDBCanvas extends HTMLElement {
       const subCtrlY = (1 - tArrowPrime) * gapStartY + tArrowPrime * newP1Y;
 
       ctx.strokeStyle = link.color;
-      ctx.lineWidth = (isLinkSelected ? this.config.linkStyle.lineWidthSelected : this.config.linkStyle.lineWidthUnselected) / globalScale;
+      ctx.lineWidth = lineWidth / globalScale;
 
       ctx.setLineDash(this.config.linkLineDash?.(link) ?? []);
       ctx.beginPath();
@@ -1724,12 +1731,12 @@ class FalkorDBCanvas extends HTMLElement {
       }
     }
 
-    ctx.font = isLinkSelected ? `${this.config.linkStyle.fontWeightSelected} ${this.config.linkStyle.fontSize}px ${this.config.linkStyle.fontFamily}` : `${this.config.linkStyle.fontWeightUnselected} ${this.config.linkStyle.fontSize}px ${this.config.linkStyle.fontFamily}`;
+    ctx.font = isLinkSelected ? `${this.config.linkStyle.fontWeightSelected} ${fontSize}px ${this.config.linkStyle.fontFamily}` : `${this.config.linkStyle.fontWeightUnselected} ${fontSize}px ${this.config.linkStyle.fontFamily}`;
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
 
     if (!skipLinkLabels) {
-      const cacheKey = `${link.relationship}_${isLinkSelected ? "700" : "400"}`;
+      const cacheKey = `${link.relationship}_${isLinkSelected ? "700" : "400"}_${fontSize}`;
       let cached = this.relationshipsTextCache.get(cacheKey);
 
       if (!cached) {
@@ -1738,7 +1745,7 @@ class FalkorDBCanvas extends HTMLElement {
 
         cached = {
           textWidth: metrics.width + bgPadding * 2,
-          textHeight: this.config.linkStyle.fontSize + bgPadding * 2,
+          textHeight: fontSize + bgPadding * 2,
         };
         this.relationshipsTextCache.set(cacheKey, cached);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,9 @@ export type { WorldBounds } from "./canvas.js";
 // Utils
 export {
   NODE_SIZE,
+  LINK_WIDTH,
+  LINK_FONT_SIZE,
+  ARROW_SIZE,
   dataToGraphData,
   graphDataToData,
   getContrastTextColor,

--- a/tests/canvas-config.test.ts
+++ b/tests/canvas-config.test.ts
@@ -70,12 +70,12 @@ describe("setConfig deep merge", () => {
   it("merges linkStyle partially — unset fields preserved", () => {
     const canvas = createCanvas();
     canvas.setConfig({ width: 800, height: 600 });
-    canvas.setConfig({ linkStyle: { lineWidthSelected: 5 } });
-    canvas.setConfig({ linkStyle: { lineWidthUnselected: 0.5 } });
+    canvas.setConfig({ linkStyle: { arrowWidthRatio: 5 } });
+    canvas.setConfig({ linkStyle: { edgeGap: 0.5 } });
 
     const internalConfig = (canvas as any).config;
-    expect(internalConfig.linkStyle.lineWidthSelected).toBe(5);
-    expect(internalConfig.linkStyle.lineWidthUnselected).toBe(0.5);
+    expect(internalConfig.linkStyle.arrowWidthRatio).toBe(5);
+    expect(internalConfig.linkStyle.edgeGap).toBe(0.5);
   });
 
   it("merges simulation config partially", () => {
@@ -534,7 +534,7 @@ describe("setConfig immediate application", () => {
     internalCanvas.relationshipsTextCache.set("test-key", { width: 50, height: 10 });
     expect(internalCanvas.relationshipsTextCache.size).toBe(1);
 
-    canvas.setConfig({ linkStyle: { lineWidthSelected: 4 } });
+    canvas.setConfig({ linkStyle: { arrowWidthRatio: 4 } });
     expect(internalCanvas.relationshipsTextCache.size).toBe(0);
   });
 

--- a/tests/canvas-lifecycle.test.ts
+++ b/tests/canvas-lifecycle.test.ts
@@ -278,20 +278,20 @@ describe("setConfig triggers render", () => {
     const internalConfig = (canvas as any).config;
     expect(internalConfig.nodeStyle.strokeWidthSelected).toBe(3);
 
-    canvas.setConfig({ linkStyle: { lineWidthSelected: 2 } });
-    expect(internalConfig.linkStyle.lineWidthSelected).toBe(2);
+    canvas.setConfig({ linkStyle: { arrowWidthRatio: 2 } });
+    expect(internalConfig.linkStyle.arrowWidthRatio).toBe(2);
   });
 
   it("setConfig before setData does not throw", () => {
     const canvas = createCanvas();
     canvas.setConfig({ width: 800, height: 600 });
     canvas.setConfig({ nodeStyle: { fontSize: 4 } });
-    canvas.setConfig({ linkStyle: { lineWidthUnselected: 0.3 } });
+    canvas.setConfig({ linkStyle: { edgeGap: 0.3 } });
     canvas.setConfig({ simulation: { chargeStrength: -100 } });
 
     const internalConfig = (canvas as any).config;
     expect(internalConfig.nodeStyle.fontSize).toBe(4);
-    expect(internalConfig.linkStyle.lineWidthUnselected).toBe(0.3);
+    expect(internalConfig.linkStyle.edgeGap).toBe(0.3);
     expect(internalConfig.simulation.chargeStrength).toBe(-100);
   });
 });

--- a/tests/canvas-rendering.test.ts
+++ b/tests/canvas-rendering.test.ts
@@ -554,6 +554,98 @@ describe("link rendering", () => {
 
     expect(ctx.setLineDash).toHaveBeenCalled();
   });
+
+  it("uses per-link width, fontSize and arrowSize overrides", () => {
+    const canvas = createCanvas();
+    canvas.setConfig({ width: 800, height: 600 });
+    canvas.setData({
+      nodes: [
+        { id: 1, labels: ["A"], visible: true, color: "#f00", data: {} },
+        { id: 2, labels: ["B"], visible: true, color: "#0f0", data: {} },
+        { id: 3, labels: ["C"], visible: true, color: "#00f", data: {} },
+      ],
+      links: [
+        { id: 1, relationship: "PLAIN", source: 1, target: 2, visible: true, color: "#888", data: {} },
+        {
+          id: 2,
+          relationship: "BIG",
+          source: 1,
+          target: 3,
+          visible: true,
+          color: "#888",
+          width: 5,
+          fontSize: 20,
+          arrowSize: 40,
+          data: {},
+        },
+      ],
+    });
+
+    const instance = getLastInstance();
+    const graphData = canvas.getGraphData();
+    graphData.nodes.forEach((node, i) => {
+      node.x = i === 0 ? -50 : 50;
+      node.y = i === 2 ? 40 : 0;
+    });
+
+    instance.callbacks.onZoom?.({ k: 1, x: 0, y: 0 });
+
+    const plainCtx = createCtxSpy();
+    instance.callbacks.linkCanvasObject!(graphData.links[0], plainCtx, 1);
+    const plainArrowPoints = plainCtx.lineTo.mock.calls.length;
+
+    const bigCtx = createCtxSpy();
+    instance.callbacks.linkCanvasObject!(graphData.links[1], bigCtx, 1);
+
+    // width override drives ctx.lineWidth (divided by globalScale = 1 here)
+    expect(bigCtx.lineWidth).toBeGreaterThan(plainCtx.lineWidth);
+    expect(bigCtx.lineWidth).toBe(5);
+
+    // fontSize override drives the label font
+    expect(bigCtx.font).toContain("20px");
+
+    // arrowSize override makes the arrowhead geometry larger
+    expect(plainArrowPoints).toBeGreaterThan(0);
+    const arrowSpread = (calls: [number, number][]) => {
+      const xs = calls.map(([x]) => x);
+      const ys = calls.map(([, y]) => y);
+      return Math.max(...xs) - Math.min(...xs) + (Math.max(...ys) - Math.min(...ys));
+    };
+    expect(arrowSpread(bigCtx.lineTo.mock.calls as [number, number][]))
+      .toBeGreaterThan(arrowSpread(plainCtx.lineTo.mock.calls as [number, number][]));
+  });
+
+  it("doubles the width and arrow size of a selected link", () => {
+    const canvas = createCanvas();
+    canvas.setConfig({ width: 800, height: 600 });
+    canvas.setData({
+      nodes: [
+        { id: 1, labels: ["A"], visible: true, color: "#f00", data: {} },
+        { id: 2, labels: ["B"], visible: true, color: "#0f0", data: {} },
+      ],
+      links: [
+        { id: 1, relationship: "R", source: 1, target: 2, visible: true, color: "#888", width: 3, data: {} },
+      ],
+    });
+
+    const instance = getLastInstance();
+    const graphData = canvas.getGraphData();
+    graphData.links[0].source.x = -50;
+    graphData.links[0].source.y = 0;
+    graphData.links[0].target.x = 50;
+    graphData.links[0].target.y = 0;
+
+    instance.callbacks.onZoom?.({ k: 1, x: 0, y: 0 });
+
+    const unselectedCtx = createCtxSpy();
+    instance.callbacks.linkCanvasObject!(graphData.links[0], unselectedCtx, 1);
+    expect(unselectedCtx.lineWidth).toBe(3);
+
+    canvas.setConfig({ isLinkSelected: () => true });
+    const selectedCtx = createCtxSpy();
+    instance.callbacks.linkCanvasObject!(graphData.links[0], selectedCtx, 1);
+    expect(selectedCtx.lineWidth).toBe(6);
+  });
 });
 
 describe("nodePointerAreaPaint", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-link overrides for line width, relationship label font size, and arrowhead size.
  * Exposed standard link sizing constants for easier integration.
* **Documentation**
  * Updated configuration docs and link-style API details to reflect the new `width`, `fontSize`, and `arrowSize` per-link fields.
* **Bug Fixes**
  * Improved link rendering and label caching so font-size changes apply consistently.
* **Changes**
  * Removed several global `linkStyle` sizing controls from the example UI/API; use per-link overrides instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->