### PR TITLE
Fix captionsKeys ignoring plain strings

### DIFF
--- a/src/canvas-utils.ts
+++ b/src/canvas-utils.ts
@@ -193,6 +193,31 @@ export function graphDataToData(graphData: GraphData): Data {
 }
 
 /**
+ * Normalizes the public `captionsKeys` config into the internal tuple form.
+ * The public API accepts `Array<string | [string, boolean]>`, but every internal
+ * consumer destructures entries as `[key, exactMatch]` tuples. A bare string
+ * would otherwise destructure character-wise (`'name'` -> key `'n'`,
+ * exactMatch `'a'`), silently falling back to the node id.
+ * Bare strings default to substring matching (exactMatch = false).
+ *
+ * @param keys - Public captionsKeys value, possibly mixing strings and tuples
+ * @returns Ordered list of [key, exactMatch] tuples
+ */
+export const normalizeCaptionsKeys = (
+  keys: Array<string | [string, boolean]> | undefined
+): [string, boolean][] => {
+  if (!Array.isArray(keys)) return [];
+  return keys.reduce<[string, boolean][]>((acc, key) => {
+    if (typeof key === 'string') {
+      acc.push([key, false]);
+    } else if (Array.isArray(key) && typeof key[0] === 'string') {
+      acc.push([key[0], Boolean(key[1])]);
+    }
+    return acc;
+  }, []);
+};
+
+/**
  * Resolves which data property key to use as the node caption/label.
  * Iterates through captionKeys in order and returns the first key that
  * matches a non-empty property in node.data.

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -30,6 +30,7 @@ import {
   LINK_DISTANCE,
   LINK_FONT_SIZE,
   LINK_WIDTH,
+  normalizeCaptionsKeys,
   wrapTextForCircularNode,
 } from "./canvas-utils.js";
 import { isForceLayout, pinAllNodes, unpinAllNodes, computeTreePositions, computeRadialPositions } from "./layouts.js";
@@ -305,9 +306,16 @@ class FalkorDBCanvas extends HTMLElement {
   setConfig(config: Partial<ForceGraphConfig>) {
     this.log('Setting config:', config);
 
+    // The public API accepts captionsKeys as `Array<string | [string, boolean]>`,
+    // but every internal consumer expects [key, exactMatch] tuples. Normalize up
+    // front so bare strings don't destructure character-wise downstream.
+    const nextCaptionsKeys = config.captionsKeys !== undefined
+      ? normalizeCaptionsKeys(config.captionsKeys)
+      : undefined;
+
     // If captionsKeys or showPropertyKeyPrefix changed, invalidate cached display names and font sizes
     // so text is recomputed with the new keys on the next render.
-    if ((config.captionsKeys && JSON.stringify(config.captionsKeys) !== JSON.stringify(this.config.captionsKeys))
+    if ((nextCaptionsKeys && JSON.stringify(nextCaptionsKeys) !== JSON.stringify(this.config.captionsKeys))
       || (config.showPropertyKeyPrefix !== undefined && config.showPropertyKeyPrefix !== this.config.showPropertyKeyPrefix)) {
       this.nodeDisplayFontSize.clear();
       for (const node of this.data.nodes) {
@@ -332,8 +340,12 @@ class FalkorDBCanvas extends HTMLElement {
     }
 
     // Shallow-assign top-level scalar/function fields (after deep-merge to avoid clobbering nested objects)
-    const { largeGraph, nodeStyle, linkStyle, simulation, interaction, eventHandlers, layoutOptions, ...scalarConfig } = config;
+    const { largeGraph, nodeStyle, linkStyle, simulation, interaction, eventHandlers, layoutOptions, captionsKeys, ...scalarConfig } = config;
     Object.assign(this.config, scalarConfig);
+
+    if (nextCaptionsKeys) {
+      this.config.captionsKeys = nextCaptionsKeys;
+    }
 
     if (config.layoutOptions) {
       const lo = config.layoutOptions;

--- a/tests/canvas-config.test.ts
+++ b/tests/canvas-config.test.ts
@@ -7,6 +7,7 @@ import {
 vi.mock("force-graph", async () => import("./mocks/force-graph"));
 
 import "../src/canvas";
+import { getNodeDisplayText } from "../src/canvas-utils";
 import type { CanvasTestElement } from "./test-types";
 
 type CanvasElement = CanvasTestElement;
@@ -564,6 +565,52 @@ describe("setConfig immediate application", () => {
 
     canvas.setConfig({ captionsKeys: [["name", true]] });
     expect(data.nodes[0].displayName).toEqual(["", ""]);
+  });
+
+  it("normalizes bare-string captionsKeys into [key, exactMatch] tuples", () => {
+    const canvas = createCanvas();
+    canvas.setConfig({ width: 800, height: 600, captionsKeys: ["name"] });
+
+    expect((canvas as any).config.captionsKeys).toEqual([["name", false]]);
+  });
+
+  it("normalizes a mix of strings and tuples, preserving order and exactMatch", () => {
+    const canvas = createCanvas();
+    canvas.setConfig({
+      width: 800,
+      height: 600,
+      captionsKeys: ["title", ["name", true], ["label", false]],
+    });
+
+    expect((canvas as any).config.captionsKeys).toEqual([
+      ["title", false],
+      ["name", true],
+      ["label", false],
+    ]);
+  });
+
+  it("resolves captions from bare-string captionsKeys instead of falling back to node id", () => {
+    const canvas = createCanvas();
+    canvas.setConfig({ width: 800, height: 600, captionsKeys: ["name"] });
+    canvas.setData(SIMPLE_DATA);
+
+    const data = (canvas as any).getGraphData();
+    const text = getNodeDisplayText(data.nodes[0], (canvas as any).config.captionsKeys, false);
+    expect(text).toBe("Alice");
+  });
+
+  it("does not re-invalidate the display cache when equivalent string/tuple keys are set", () => {
+    const canvas = createCanvas();
+    canvas.setConfig({ width: 800, height: 600, captionsKeys: ["name"] });
+    canvas.setData(SIMPLE_DATA);
+
+    const data = (canvas as any).getGraphData();
+    data.nodes[0].displayName = ["cached", ""];
+
+    // ["name"] normalizes to [["name", false]] — same as what is already stored,
+    // so the cache-invalidation check must treat this as unchanged.
+    canvas.setConfig({ captionsKeys: [["name", false]] });
+    expect(data.nodes[0].displayName).toEqual(["cached", ""]);
   });
 
   // --- layout ---


### PR DESCRIPTION
Passing `captionsKeys` as plain strings doesn't work — nodes just render their id.

`captionsKeys` is typed as `Array<string | [string, boolean]>`, but only the tuple form actually works. `setConfig` stored whatever you gave it, and `resolveNodeCaption` does `for (const [requestedKey, exactMatch] of captionKeys)`. So a string like `'name'` gets destructured character-wise into key `'n'` / exactMatch `'a'`, which never matches a property, and the node quietly falls back to showing its id.

Ran into this while using the component — `captionsKeys: ['name']` drew `42` instead of the node's name, with no warning. `[['name', true]]` worked, which is what pointed at the cause.

## Fix

Normalize in `setConfig` so the internal config always holds tuples (`InternalForceGraphConfig` already declares `[string, boolean][]`, that conversion was just never done anywhere). Bare strings default to `exactMatch: false`.

One thing worth noting: the normalization has to happen *before* the cache-invalidation check. Otherwise `['name']` never string-equals the stored `[['name', false]]` and we'd wipe the display-name cache on every `setConfig` call.

No behaviour change for anyone already passing tuples.

## Tests

The existing tests only ever used the tuple form, which is why this slipped through. Added four cases: normalization, mixed string/tuple input, resolving a caption from a bare string, and the cache not being invalidated when the normalized value is unchanged. All four fail without the fix.

Also checked it in a real browser against a build of this branch, reading back what the renderer actually painted:

| `captionsKeys` | stored internally | rendered |
| --- | --- | --- |
| `['name']` | `[["name",false]]` | `HELLO-CAPTION` (was `42`) |
| `[['name',true]]` | `[["name",true]]` | `HELLO-CAPTION` (unchanged) |
| `['title','name']` | `[["title",false],["name",false]]` | falls through to `name` |
| `[]` | `[]` | `42` — id fallback still intact |

Suite is 175 passing. The one failing test (`canvas-rendering` → per-link arrowSize override) already fails on `main` and is unrelated to this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Caption key settings now accept simple strings or detailed matching options.
  - Simple caption keys default to substring matching, while exact-match options remain supported.
  - Invalid caption key entries are safely ignored.

- **Bug Fixes**
  - Improved caption resolution and configuration handling.
  - Prevented unnecessary display updates when equivalent caption settings are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->