### PR TITLE
feat: enhance captionsKeys configuration with normalization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Configuration is passed to `setConfig()` as a `ForceGraphConfig` object. It is o
 | `layoutMode` | `'force'` | Layout algorithm: `'force'` \| `'tree'` \| `'radial'` |
 | `layoutOptions` | `{}` | Per-layout options (see [Layout Modes](#layout-modes)) |
 | `animation` | | Enable/disable layout animation |
-| `captionsKeys` | `[]` | Node property keys to display as labels |
+| `captionsKeys` | `[]` | Ordered node property keys to display as labels. Each entry is a plain string (fuzzy, case-insensitive match) or a `[key, exactMatch]` tuple — e.g. `['name', ['Title', true]]`. Falls back to the node ID if none match |
 | `showPropertyKeyPrefix` | `false` | Show property key prefix in node labels |
 | `pinOnDragEnd` | `false` | Pin nodes after dragging |
 | `isNodeSelected` | | Function: `(node: GraphNode) => boolean` |

--- a/examples/falkordb-canvas.example.html
+++ b/examples/falkordb-canvas.example.html
@@ -880,7 +880,7 @@
         <tr><td><code>foregroundColor</code></td><td>string</td><td>'#1a1a1a'</td><td>Stroke/border color</td></tr>
         <tr><td><code>animation</code></td><td>boolean</td><td>false</td><td>Continuous simulation</td></tr>
         <tr><td><code>pinOnDragEnd</code></td><td>boolean</td><td>false</td><td>Pin after drag</td></tr>
-        <tr><td><code>captionsKeys</code></td><td>Array</td><td>[]</td><td>Node label keys: ['name', true]</td></tr>
+        <tr><td><code>captionsKeys</code></td><td>Array</td><td>[]</td><td>Node label keys: ['name'] (fuzzy) or [['name', true]] (exact)</td></tr>
         <tr><td><code>showPropertyKeyPrefix</code></td><td>boolean</td><td>false</td><td>Show "key: value" in labels</td></tr>
         <tr><td><code>layoutMode</code></td><td>string</td><td>'force'</td><td>Layout algorithm</td></tr>
         <tr><td><code>isNodeSelected</code></td><td>function</td><td>undefined</td><td>(node) => boolean</td></tr>

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -236,7 +236,7 @@ export interface ForceGraphConfig {
    * @example ["name", "title"] — tries 'name' first, then 'title'
    * @example [["Name", true]] — exact match only for 'Name'
    */
-  captionsKeys?: Array<string | [string, boolean]>;
+  captionsKeys?: Array<string | [string, boolean?]>;
   /** When true, display the property key prefix before the value in labels (e.g. "name: Foo"). Default: false */
   showPropertyKeyPrefix?: boolean;
   /** When true, nodes stay pinned at their position after being dragged. Default: false */

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -292,6 +292,7 @@ export interface ForceGraphConfig {
 export interface InternalForceGraphConfig extends Omit<ForceGraphConfig, 'backgroundColor' | 'foregroundColor' | 'captionsKeys' | 'showPropertyKeyPrefix' | 'layoutMode' | 'layoutOptions' | 'pinOnDragEnd' | 'nodeStyle' | 'linkStyle' | 'simulation' | 'interaction' | 'largeGraph'> {
   backgroundColor: string;
   foregroundColor: string;
+  /** Normalized from `ForceGraphConfig.captionsKeys` — bare strings become `[key, false]`. */
   captionsKeys: [string, boolean][];
   showPropertyKeyPrefix: boolean;
   layoutMode: LayoutMode;

--- a/src/canvas-utils.ts
+++ b/src/canvas-utils.ts
@@ -200,7 +200,7 @@ export function graphDataToData(graphData: GraphData): Data {
  * @returns Normalized `[key, exactMatch]` tuples
  */
 export const normalizeCaptionsKeys = (
-  captionKeys: Array<string | [string, boolean]> | undefined
+  captionKeys: Array<string | [string, boolean?]> | undefined
 ): [string, boolean][] =>
   (captionKeys ?? []).map((key): [string, boolean] =>
     typeof key === "string" ? [key, false] : [key[0], key[1] ?? false]

--- a/src/canvas-utils.ts
+++ b/src/canvas-utils.ts
@@ -193,6 +193,20 @@ export function graphDataToData(graphData: GraphData): Data {
 }
 
 /**
+ * Normalizes user-supplied caption keys into `[key, exactMatch]` tuples.
+ * Bare strings default to a fuzzy (non-exact) match.
+ *
+ * @param captionKeys - Caption keys as plain strings and/or `[key, exactMatch]` tuples
+ * @returns Normalized `[key, exactMatch]` tuples
+ */
+export const normalizeCaptionsKeys = (
+  captionKeys: Array<string | [string, boolean]> | undefined
+): [string, boolean][] =>
+  (captionKeys ?? []).map((key): [string, boolean] =>
+    typeof key === "string" ? [key, false] : [key[0], key[1] ?? false]
+  );
+
+/**
  * Resolves which data property key to use as the node caption/label.
  * Iterates through captionKeys in order and returns the first key that
  * matches a non-empty property in node.data.

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -30,6 +30,7 @@ import {
   LINK_DISTANCE,
   LINK_FONT_SIZE,
   LINK_WIDTH,
+  normalizeCaptionsKeys,
   wrapTextForCircularNode,
 } from "./canvas-utils.js";
 import { isForceLayout, pinAllNodes, unpinAllNodes, computeTreePositions, computeRadialPositions } from "./layouts.js";
@@ -299,15 +300,20 @@ class FalkorDBCanvas extends HTMLElement {
    * Update the canvas configuration. Accepts a partial config object —
    * only the provided fields are changed; others retain their current values.
    * Nested objects (nodeStyle, linkStyle, simulation, interaction, largeGraph) are deep-merged.
+   * `captionsKeys` entries given as bare strings are normalized to `[key, false]` (fuzzy match).
    *
    * @param config - Partial configuration to apply
    */
   setConfig(config: Partial<ForceGraphConfig>) {
     this.log('Setting config:', config);
 
+    const captionsKeys = config.captionsKeys
+      ? normalizeCaptionsKeys(config.captionsKeys)
+      : undefined;
+
     // If captionsKeys or showPropertyKeyPrefix changed, invalidate cached display names and font sizes
     // so text is recomputed with the new keys on the next render.
-    if ((config.captionsKeys && JSON.stringify(config.captionsKeys) !== JSON.stringify(this.config.captionsKeys))
+    if ((captionsKeys && JSON.stringify(captionsKeys) !== JSON.stringify(this.config.captionsKeys))
       || (config.showPropertyKeyPrefix !== undefined && config.showPropertyKeyPrefix !== this.config.showPropertyKeyPrefix)) {
       this.nodeDisplayFontSize.clear();
       for (const node of this.data.nodes) {
@@ -334,6 +340,10 @@ class FalkorDBCanvas extends HTMLElement {
     // Shallow-assign top-level scalar/function fields (after deep-merge to avoid clobbering nested objects)
     const { largeGraph, nodeStyle, linkStyle, simulation, interaction, eventHandlers, layoutOptions, ...scalarConfig } = config;
     Object.assign(this.config, scalarConfig);
+
+    if (captionsKeys) {
+      this.config.captionsKeys = captionsKeys;
+    }
 
     if (config.layoutOptions) {
       const lo = config.layoutOptions;

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -337,8 +337,9 @@ class FalkorDBCanvas extends HTMLElement {
       }
     }
 
-    // Shallow-assign top-level scalar/function fields (after deep-merge to avoid clobbering nested objects)
-    const { largeGraph, nodeStyle, linkStyle, simulation, interaction, eventHandlers, layoutOptions, ...scalarConfig } = config;
+    // Shallow-assign top-level scalar/function fields (after deep-merge to avoid clobbering nested objects).
+    // `captionsKeys` is excluded so only the normalized tuples are ever written to the internal config.
+    const { largeGraph, nodeStyle, linkStyle, simulation, interaction, eventHandlers, layoutOptions, captionsKeys: _captionsKeys, ...scalarConfig } = config;
     Object.assign(this.config, scalarConfig);
 
     if (captionsKeys) {

--- a/tests/canvas-config.test.ts
+++ b/tests/canvas-config.test.ts
@@ -566,6 +566,23 @@ describe("setConfig immediate application", () => {
     expect(data.nodes[0].displayName).toEqual(["", ""]);
   });
 
+  it("normalizes bare-string and flagless-tuple captionsKeys to [key, false]", () => {
+    const canvas = createCanvas();
+    canvas.setConfig({ captionsKeys: ["name", ["title"], ["Label", true]] });
+
+    const internalConfig = (canvas as any).config;
+    expect(internalConfig.captionsKeys).toEqual([["name", false], ["title", false], ["Label", true]]);
+  });
+
+  it("preserves captionsKeys when a later setConfig omits them", () => {
+    const canvas = createCanvas();
+    canvas.setConfig({ captionsKeys: ["name"] });
+    canvas.setConfig({ captionsKeys: undefined, width: 400 });
+
+    const internalConfig = (canvas as any).config;
+    expect(internalConfig.captionsKeys).toEqual([["name", false]]);
+  });
+
   // --- layout ---
 
   it("setLayout applies layout to force-graph immediately", () => {

--- a/tests/canvas-rendering.test.ts
+++ b/tests/canvas-rendering.test.ts
@@ -338,6 +338,34 @@ describe("node rendering", () => {
     expect(textArg).toContain("Hello");
   });
 
+  it("resolves caption from a bare-string captionsKeys entry", () => {
+    const canvas = createCanvas();
+    canvas.setConfig({
+      width: 800,
+      height: 600,
+      captionsKeys: ["Name"], // bare string → fuzzy, case-insensitive match
+      largeGraph: { lowZoomThreshold: 0.5 },
+    });
+    canvas.setData({
+      nodes: [{ id: 1, labels: ["A"], visible: true, color: "#f00", data: { displayName: "Hello" } }],
+      links: [],
+    });
+
+    const instance = getLastInstance();
+    const graphData = canvas.getGraphData();
+    const node = graphData.nodes[0];
+    node.x = 0;
+    node.y = 0;
+    instance.callbacks.onZoom?.({ k: 1, x: 0, y: 0 });
+
+    const ctx = createCtxSpy();
+    instance.callbacks.nodeCanvasObject!(node, ctx);
+
+    expect(ctx.fillText).toHaveBeenCalled();
+    const textArg = ctx.fillText.mock.calls[0]?.[0];
+    expect(textArg).toContain("Hello");
+  });
+
   it("falls back to node ID if no caption key matches", () => {
     const canvas = createCanvas();
     canvas.setConfig({

--- a/tests/canvas-utils-captions.test.ts
+++ b/tests/canvas-utils-captions.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  getNodeDisplayKey,
+  getNodeDisplayText,
+  normalizeCaptionsKeys,
+} from "../src/canvas-utils";
+import type { Node } from "../src/canvas-types";
+
+const makeNode = (data: Record<string, unknown>, id = 1): Node => ({
+  id,
+  labels: ["A"],
+  visible: true,
+  color: "#f00",
+  data,
+});
+
+describe("normalizeCaptionsKeys", () => {
+  it.each([
+    ["undefined", undefined, []],
+    ["empty array", [], []],
+    ["bare strings", ["name", "title"], [["name", false], ["title", false]]],
+    ["flagless tuples", [["name"], ["title"]], [["name", false], ["title", false]]],
+    ["full tuples", [["name", true], ["title", false]], [["name", true], ["title", false]]],
+    ["mixed forms", ["name", ["title"], ["Label", true]], [["name", false], ["title", false], ["Label", true]]],
+  ])("normalizes %s", (_label, input, expected) => {
+    expect(normalizeCaptionsKeys(input as Parameters<typeof normalizeCaptionsKeys>[0])).toEqual(expected);
+  });
+
+  it("preserves the caller's key order", () => {
+    expect(normalizeCaptionsKeys(["c", "a", "b"]).map(([key]) => key)).toEqual(["c", "a", "b"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input: Array<string | [string, boolean?]> = ["name", ["title"]];
+    normalizeCaptionsKeys(input);
+    expect(input).toEqual(["name", ["title"]]);
+  });
+});
+
+describe("getNodeDisplayText", () => {
+  it("matches fuzzily and case-insensitively for a bare-string key", () => {
+    const node = makeNode({ displayName: "Hello" });
+    expect(getNodeDisplayText(node, normalizeCaptionsKeys(["name"]), false)).toBe("Hello");
+  });
+
+  it("requires an exact key match when the flag is true", () => {
+    const node = makeNode({ displayName: "Hello" });
+    expect(getNodeDisplayText(node, normalizeCaptionsKeys([["name", true]]), false)).toBe("1");
+    expect(getNodeDisplayText(node, normalizeCaptionsKeys([["displayName", true]]), false)).toBe("Hello");
+  });
+
+  it("uses the first key that resolves to a non-empty value", () => {
+    const node = makeNode({ title: "", name: "Bob" });
+    expect(getNodeDisplayText(node, normalizeCaptionsKeys(["title", "name"]), false)).toBe("Bob");
+  });
+
+  it("skips whitespace-only values", () => {
+    const node = makeNode({ name: "   ", title: "Boss" });
+    expect(getNodeDisplayText(node, normalizeCaptionsKeys(["name", "title"]), false)).toBe("Boss");
+  });
+
+  it("falls back to the node ID when no key matches", () => {
+    const node = makeNode({ other: "x" }, 42);
+    expect(getNodeDisplayText(node, normalizeCaptionsKeys(["name"]), false)).toBe("42");
+  });
+
+  it("falls back to the node ID for an empty caption key list", () => {
+    const node = makeNode({ name: "Bob" }, 7);
+    expect(getNodeDisplayText(node, normalizeCaptionsKeys(undefined), false)).toBe("7");
+  });
+
+  it("prefixes the requested key — not the matched key — when showPropertyKeyPrefix is on", () => {
+    const node = makeNode({ displayName: "Hello" });
+    expect(getNodeDisplayText(node, normalizeCaptionsKeys(["name"]), true)).toBe("name: Hello");
+  });
+
+  it("prefixes the fallback with 'ID' when showPropertyKeyPrefix is on", () => {
+    const node = makeNode({}, 5);
+    expect(getNodeDisplayText(node, normalizeCaptionsKeys(["name"]), true)).toBe("ID: 5");
+  });
+
+  it("stringifies non-string values", () => {
+    const node = makeNode({ count: 0 });
+    expect(getNodeDisplayText(node, normalizeCaptionsKeys(["count"]), false)).toBe("0");
+  });
+});
+
+describe("getNodeDisplayKey", () => {
+  it("returns the matched data key, not the requested one", () => {
+    const node = makeNode({ displayName: "Hello" });
+    expect(getNodeDisplayKey(node, normalizeCaptionsKeys(["name"]))).toBe("displayName");
+  });
+
+  it("returns 'id' when no key matches", () => {
+    expect(getNodeDisplayKey(makeNode({}), normalizeCaptionsKeys(["name"]))).toBe("id");
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Caption keys now support both fuzzy, case-insensitive matching and optional exact matching.
  * Caption key settings are normalized consistently, with omitted match options defaulting to fuzzy matching.
  * Nodes fall back to displaying their ID when no configured caption key matches.

* **Documentation**
  * Updated configuration references and examples to explain the enhanced caption key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->